### PR TITLE
Add client microphone streaming support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "core/moonlight-common-c"]
 	path = core/moonlight-common-c
-	url = https://github.com/moonlight-stream/moonlight-common-c.git
+	url = https://github.com/logabell/moonlight-common-c-mic.git
 [submodule "third_party/lvgl"]
 	path = third_party/lvgl
 	url = https://github.com/mariotaku/lvgl.git

--- a/src/app/app_settings.c
+++ b/src/app/app_settings.c
@@ -53,8 +53,10 @@ void settings_initialize(app_settings_t *config, char *conf_dir) {
     set_string(&config->audio_backend, "auto");
     set_string(&config->decoder, "auto");
     config->audio_device = NULL;
+    set_string(&config->microphone_device, "");
     config->sops = true;
     config->localaudio = false;
+    config->enable_microphone = false;
     config->fullscreen = true;
     if (!config->fullscreen) {
         config->window_state.w = 1280;
@@ -139,6 +141,10 @@ bool settings_save(app_settings_t *config) {
     if (config->audio_device && config->audio_device[0]) {
         ini_write_string(fp, "device", config->audio_device);
     }
+    ini_write_bool(fp, "microphone", config->enable_microphone);
+    if (config->microphone_device && config->microphone_device[0]) {
+        ini_write_string(fp, "microphone_device", config->microphone_device);
+    }
     ini_write_string(fp, "surround", serialize_audio_config(config->stream.audioConfiguration));
 
     if (!config->fullscreen) {
@@ -156,6 +162,7 @@ void settings_clear(app_settings_t *config) {
     free_nullable(config->decoder);
     free_nullable(config->audio_backend);
     free_nullable(config->audio_device);
+    free_nullable(config->microphone_device);
     free_nullable(config->language);
     free_nullable(config->ini_path);
     free_nullable(config->condb_path);
@@ -271,6 +278,10 @@ static int settings_parse(app_settings_t *config, const char *section, const cha
         set_string(&config->audio_backend, value);
     } else if (INI_FULL_MATCH("audio", "device")) {
         set_string(&config->audio_device, value);
+    } else if (INI_FULL_MATCH("audio", "microphone")) {
+        config->enable_microphone = INI_IS_TRUE(value);
+    } else if (INI_FULL_MATCH("audio", "microphone_device")) {
+        set_string(&config->microphone_device, value);
     } else if (INI_NAME_MATCH("language")) {
         set_string(&config->language, value);
     } else if (INI_NAME_MATCH("fullscreen")) {

--- a/src/app/app_settings.h
+++ b/src/app/app_settings.h
@@ -33,9 +33,11 @@ typedef struct app_settings_t {
     char *decoder;
     char *audio_backend;
     char *audio_device;
+    char *microphone_device;
     char *language;
     bool sops;
     bool localaudio;
+    bool enable_microphone;
     bool fullscreen;
     window_state_t window_state;
     int rotate;

--- a/src/app/stream/audio/CMakeLists.txt
+++ b/src/app/stream/audio/CMakeLists.txt
@@ -1,1 +1,1 @@
-target_sources(moonlight-lib PRIVATE session_audio.c)
+target_sources(moonlight-lib PRIVATE session_audio.c microphone_capture.c)

--- a/src/app/stream/audio/microphone_capture.c
+++ b/src/app/stream/audio/microphone_capture.c
@@ -1,0 +1,354 @@
+#include "microphone_capture.h"
+
+#include <Limelight.h>
+#include <opus.h>
+#include <SDL.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "logging.h"
+
+#define MIC_SAMPLE_RATE 48000
+#define MIC_CHANNELS 1
+#define MIC_FRAME_SIZE 960
+#define MIC_BITRATE 64000
+#define MIC_PACKET_BUFFER_SIZE 1400
+#define MIC_MAX_BUFFERED_SAMPLES (MIC_FRAME_SIZE * 12)
+#define MIC_FRAME_DURATION_US ((uint64_t) MIC_FRAME_SIZE * 1000000ULL / MIC_SAMPLE_RATE)
+
+struct microphone_capture_t {
+    SDL_AudioDeviceID device_id;
+    SDL_AudioSpec obtained_spec;
+    OpusEncoder *encoder;
+    opus_int16 *sample_buffer;
+    size_t sample_buffer_start;
+    size_t sample_buffer_count;
+    SDL_mutex *buffer_mutex;
+    SDL_cond *buffer_cond;
+    SDL_Thread *encoder_thread;
+    bool streaming;
+    bool stop_thread;
+    bool first_packet_logged;
+    unsigned char encoded_packet[MIC_PACKET_BUFFER_SIZE];
+};
+
+static void microphone_capture_audio_cb(void *userdata, Uint8 *stream, int len);
+
+static int microphone_capture_encoder_thread(void *data);
+
+static void microphone_capture_clear_locked(microphone_capture_t *capture);
+
+static void microphone_capture_push_locked(microphone_capture_t *capture, const opus_int16 *samples, size_t count);
+
+static bool microphone_capture_pop_locked(microphone_capture_t *capture, opus_int16 *samples, size_t count);
+
+static uint64_t microphone_capture_now_us(uint64_t performance_frequency);
+
+static void microphone_capture_delay_until_us(uint64_t target_us, uint64_t performance_frequency);
+
+static void microphone_capture_audio_cb(void *userdata, Uint8 *stream, int len) {
+    microphone_capture_t *capture = userdata;
+    if (capture == NULL || stream == NULL || len <= 0) {
+        return;
+    }
+
+    SDL_LockMutex(capture->buffer_mutex);
+    if (capture->streaming) {
+        microphone_capture_push_locked(capture, (const opus_int16 *) stream, (size_t) len / sizeof(opus_int16));
+        SDL_CondSignal(capture->buffer_cond);
+    }
+    SDL_UnlockMutex(capture->buffer_mutex);
+}
+
+microphone_capture_t *microphone_capture_create(const char *device_name) {
+    microphone_capture_t *capture = calloc(1, sizeof(microphone_capture_t));
+    if (capture == NULL) {
+        return NULL;
+    }
+
+    capture->buffer_mutex = SDL_CreateMutex();
+    capture->buffer_cond = SDL_CreateCond();
+    capture->sample_buffer = calloc(MIC_MAX_BUFFERED_SAMPLES, sizeof(opus_int16));
+    if (capture->buffer_mutex == NULL || capture->buffer_cond == NULL || capture->sample_buffer == NULL) {
+        microphone_capture_destroy(capture);
+        return NULL;
+    }
+
+    if (SDL_InitSubSystem(SDL_INIT_AUDIO) != 0) {
+        commons_log_warn("Microphone", "Failed to initialize SDL audio for microphone capture: %s", SDL_GetError());
+        microphone_capture_destroy(capture);
+        return NULL;
+    }
+
+    int opus_error = OPUS_OK;
+    capture->encoder = opus_encoder_create(MIC_SAMPLE_RATE, MIC_CHANNELS, OPUS_APPLICATION_VOIP, &opus_error);
+    if (capture->encoder == NULL || opus_error != OPUS_OK) {
+        commons_log_warn("Microphone", "Failed to create Opus encoder for microphone capture: %s",
+                         opus_strerror(opus_error));
+        microphone_capture_destroy(capture);
+        return NULL;
+    }
+
+    opus_encoder_ctl(capture->encoder, OPUS_SET_BITRATE(MIC_BITRATE));
+    opus_encoder_ctl(capture->encoder, OPUS_SET_VBR(1));
+    opus_encoder_ctl(capture->encoder, OPUS_SET_COMPLEXITY(10));
+    opus_encoder_ctl(capture->encoder, OPUS_SET_SIGNAL(OPUS_SIGNAL_VOICE));
+    opus_encoder_ctl(capture->encoder, OPUS_SET_LSB_DEPTH(16));
+    opus_encoder_ctl(capture->encoder, OPUS_SET_DTX(0));
+    opus_encoder_ctl(capture->encoder, OPUS_SET_INBAND_FEC(1));
+    opus_encoder_ctl(capture->encoder, OPUS_SET_PACKET_LOSS_PERC(5));
+    opus_encoder_ctl(capture->encoder, OPUS_SET_EXPERT_FRAME_DURATION(OPUS_FRAMESIZE_20_MS));
+
+    SDL_AudioSpec desired = {0};
+    desired.freq = MIC_SAMPLE_RATE;
+    desired.format = AUDIO_S16SYS;
+    desired.channels = MIC_CHANNELS;
+    desired.samples = MIC_FRAME_SIZE;
+    desired.callback = microphone_capture_audio_cb;
+    desired.userdata = capture;
+
+    const char *selected_device = device_name != NULL && device_name[0] != '\0' ? device_name : NULL;
+    capture->device_id = SDL_OpenAudioDevice(selected_device, SDL_TRUE, &desired, &capture->obtained_spec, 0);
+    if (capture->device_id == 0 && selected_device != NULL) {
+        commons_log_warn("Microphone", "Failed to open microphone '%s': %s. Falling back to default input.",
+                         selected_device, SDL_GetError());
+        capture->device_id = SDL_OpenAudioDevice(NULL, SDL_TRUE, &desired, &capture->obtained_spec, 0);
+    }
+
+    if (capture->device_id == 0) {
+        commons_log_warn("Microphone", "Failed to open microphone capture device: %s", SDL_GetError());
+        microphone_capture_destroy(capture);
+        return NULL;
+    }
+
+    commons_log_info("Microphone", "Capture device %s (%d Hz, %d channels, format 0x%x, callback %d samples)",
+                     selected_device != NULL ? selected_device : "<default>",
+                     capture->obtained_spec.freq, capture->obtained_spec.channels,
+                     capture->obtained_spec.format, capture->obtained_spec.samples);
+
+    if (capture->obtained_spec.freq != MIC_SAMPLE_RATE ||
+        capture->obtained_spec.channels != MIC_CHANNELS ||
+        capture->obtained_spec.format != AUDIO_S16SYS) {
+        commons_log_warn("Microphone", "Unsupported microphone capture format: %d Hz, %d channels, format 0x%x",
+                         capture->obtained_spec.freq, capture->obtained_spec.channels, capture->obtained_spec.format);
+        microphone_capture_destroy(capture);
+        return NULL;
+    }
+
+    if (capture->obtained_spec.samples != MIC_FRAME_SIZE) {
+        commons_log_info("Microphone",
+                         "Backend callback size is %d samples; outgoing microphone packets stay paced at %d samples",
+                         capture->obtained_spec.samples, MIC_FRAME_SIZE);
+    }
+
+    capture->encoder_thread = SDL_CreateThread(microphone_capture_encoder_thread, "mic-encoder", capture);
+    if (capture->encoder_thread == NULL) {
+        commons_log_warn("Microphone", "Failed to create microphone encoder thread: %s", SDL_GetError());
+        microphone_capture_destroy(capture);
+        return NULL;
+    }
+
+    SDL_PauseAudioDevice(capture->device_id, 1);
+    return capture;
+}
+
+bool microphone_capture_start(microphone_capture_t *capture) {
+    if (capture == NULL || capture->device_id == 0 || !LiIsMicrophoneStreamActive()) {
+        return false;
+    }
+
+    SDL_LockMutex(capture->buffer_mutex);
+    microphone_capture_clear_locked(capture);
+    capture->first_packet_logged = false;
+    capture->streaming = true;
+    SDL_CondSignal(capture->buffer_cond);
+    SDL_UnlockMutex(capture->buffer_mutex);
+
+    commons_log_info("Microphone", "Client microphone capture started");
+    SDL_PauseAudioDevice(capture->device_id, 0);
+    return true;
+}
+
+void microphone_capture_stop(microphone_capture_t *capture) {
+    if (capture == NULL || capture->buffer_mutex == NULL) {
+        return;
+    }
+
+    if (capture->device_id != 0) {
+        SDL_PauseAudioDevice(capture->device_id, 1);
+    }
+
+    SDL_LockMutex(capture->buffer_mutex);
+    capture->streaming = false;
+    microphone_capture_clear_locked(capture);
+    SDL_CondSignal(capture->buffer_cond);
+    SDL_UnlockMutex(capture->buffer_mutex);
+}
+
+void microphone_capture_destroy(microphone_capture_t *capture) {
+    if (capture == NULL) {
+        return;
+    }
+
+    microphone_capture_stop(capture);
+
+    if (capture->buffer_mutex != NULL) {
+        SDL_LockMutex(capture->buffer_mutex);
+        capture->stop_thread = true;
+        if (capture->buffer_cond != NULL) {
+            SDL_CondSignal(capture->buffer_cond);
+        }
+        SDL_UnlockMutex(capture->buffer_mutex);
+    }
+
+    if (capture->encoder_thread != NULL) {
+        SDL_WaitThread(capture->encoder_thread, NULL);
+    }
+
+    if (capture->device_id != 0) {
+        SDL_CloseAudioDevice(capture->device_id);
+    }
+    if (capture->encoder != NULL) {
+        opus_encoder_destroy(capture->encoder);
+    }
+    if (capture->buffer_cond != NULL) {
+        SDL_DestroyCond(capture->buffer_cond);
+    }
+    if (capture->buffer_mutex != NULL) {
+        SDL_DestroyMutex(capture->buffer_mutex);
+    }
+
+    free(capture->sample_buffer);
+    free(capture);
+}
+
+static int microphone_capture_encoder_thread(void *data) {
+    microphone_capture_t *capture = data;
+    const uint64_t performance_frequency = SDL_GetPerformanceFrequency();
+    opus_int16 frame[MIC_FRAME_SIZE];
+    uint64_t next_send_deadline_us = 0;
+    bool pacing_active = false;
+
+    for (;;) {
+        SDL_LockMutex(capture->buffer_mutex);
+        while (!capture->stop_thread && (!capture->streaming || capture->sample_buffer_count < MIC_FRAME_SIZE)) {
+            if (!capture->streaming) {
+                pacing_active = false;
+            }
+            SDL_CondWait(capture->buffer_cond, capture->buffer_mutex);
+        }
+        if (capture->stop_thread) {
+            SDL_UnlockMutex(capture->buffer_mutex);
+            break;
+        }
+        if (!microphone_capture_pop_locked(capture, frame, MIC_FRAME_SIZE)) {
+            pacing_active = false;
+            SDL_UnlockMutex(capture->buffer_mutex);
+            continue;
+        }
+        SDL_UnlockMutex(capture->buffer_mutex);
+
+        uint64_t now_us = microphone_capture_now_us(performance_frequency);
+        if (!pacing_active) {
+            next_send_deadline_us = now_us;
+            pacing_active = true;
+        } else if (now_us > next_send_deadline_us + MIC_FRAME_DURATION_US * 2) {
+            next_send_deadline_us = now_us;
+        }
+
+        if (next_send_deadline_us > now_us) {
+            microphone_capture_delay_until_us(next_send_deadline_us, performance_frequency);
+        }
+        next_send_deadline_us += MIC_FRAME_DURATION_US;
+
+        int encoded_bytes = opus_encode(capture->encoder, frame, MIC_FRAME_SIZE, capture->encoded_packet,
+                                        (opus_int32) sizeof(capture->encoded_packet));
+        if (encoded_bytes <= 0) {
+            continue;
+        }
+
+        int send_result = LiSendMicrophoneOpusDataEx(capture->encoded_packet, encoded_bytes, MIC_FRAME_SIZE);
+        if (send_result >= 0 && !capture->first_packet_logged) {
+            commons_log_info("Microphone", "Sent first microphone packet (%d bytes Opus)", encoded_bytes);
+            capture->first_packet_logged = true;
+        } else if (send_result < 0) {
+            commons_log_warn("Microphone", "Failed to send microphone packet to host");
+        }
+    }
+
+    return 0;
+}
+
+static void microphone_capture_clear_locked(microphone_capture_t *capture) {
+    capture->sample_buffer_start = 0;
+    capture->sample_buffer_count = 0;
+}
+
+static void microphone_capture_push_locked(microphone_capture_t *capture, const opus_int16 *samples, size_t count) {
+    if (count >= MIC_MAX_BUFFERED_SAMPLES) {
+        samples += count - MIC_MAX_BUFFERED_SAMPLES;
+        count = MIC_MAX_BUFFERED_SAMPLES;
+        microphone_capture_clear_locked(capture);
+    }
+
+    if (capture->sample_buffer_count + count > MIC_MAX_BUFFERED_SAMPLES) {
+        size_t drop = capture->sample_buffer_count + count - MIC_MAX_BUFFERED_SAMPLES;
+        capture->sample_buffer_start = (capture->sample_buffer_start + drop) % MIC_MAX_BUFFERED_SAMPLES;
+        capture->sample_buffer_count -= drop;
+    }
+
+    size_t write_pos = (capture->sample_buffer_start + capture->sample_buffer_count) % MIC_MAX_BUFFERED_SAMPLES;
+    size_t first_chunk = MIC_MAX_BUFFERED_SAMPLES - write_pos;
+    if (first_chunk > count) {
+        first_chunk = count;
+    }
+
+    memcpy(capture->sample_buffer + write_pos, samples, first_chunk * sizeof(opus_int16));
+    if (count > first_chunk) {
+        memcpy(capture->sample_buffer, samples + first_chunk, (count - first_chunk) * sizeof(opus_int16));
+    }
+
+    capture->sample_buffer_count += count;
+}
+
+static bool microphone_capture_pop_locked(microphone_capture_t *capture, opus_int16 *samples, size_t count) {
+    if (capture->sample_buffer_count < count) {
+        return false;
+    }
+
+    size_t first_chunk = MIC_MAX_BUFFERED_SAMPLES - capture->sample_buffer_start;
+    if (first_chunk > count) {
+        first_chunk = count;
+    }
+
+    memcpy(samples, capture->sample_buffer + capture->sample_buffer_start, first_chunk * sizeof(opus_int16));
+    if (count > first_chunk) {
+        memcpy(samples + first_chunk, capture->sample_buffer, (count - first_chunk) * sizeof(opus_int16));
+    }
+
+    capture->sample_buffer_start = (capture->sample_buffer_start + count) % MIC_MAX_BUFFERED_SAMPLES;
+    capture->sample_buffer_count -= count;
+    return true;
+}
+
+static uint64_t microphone_capture_now_us(uint64_t performance_frequency) {
+    return SDL_GetPerformanceCounter() * 1000000ULL / performance_frequency;
+}
+
+static void microphone_capture_delay_until_us(uint64_t target_us, uint64_t performance_frequency) {
+    for (;;) {
+        uint64_t now_us = microphone_capture_now_us(performance_frequency);
+        if (now_us >= target_us) {
+            return;
+        }
+
+        uint64_t remaining_us = target_us - now_us;
+        if (remaining_us > 1000) {
+            SDL_Delay((Uint32) (remaining_us / 1000));
+        } else {
+            SDL_Delay(1);
+        }
+    }
+}

--- a/src/app/stream/audio/microphone_capture.h
+++ b/src/app/stream/audio/microphone_capture.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <stdbool.h>
+
+typedef struct microphone_capture_t microphone_capture_t;
+
+microphone_capture_t *microphone_capture_create(const char *device_name);
+
+bool microphone_capture_start(microphone_capture_t *capture);
+
+void microphone_capture_stop(microphone_capture_t *capture);
+
+void microphone_capture_destroy(microphone_capture_t *capture);

--- a/src/app/stream/session.c
+++ b/src/app/stream/session.c
@@ -16,6 +16,7 @@
 #include "input/input_gamepad.h"
 #include "app_session.h"
 #include "session_worker.h"
+#include "audio/microphone_capture.h"
 #include "stream/input/session_virt_mouse.h"
 
 // Expected luminance values in SEI are in units of 0.0001 cd/m2
@@ -87,10 +88,12 @@ void session_destroy(session_t *session) {
     session_interrupt(session, false, STREAMING_INTERRUPT_QUIT);
     session_input_deinit(&session->input);
     SDL_WaitThread(session->thread, NULL);
+    microphone_capture_destroy(session->microphone_capture);
     serverdata_free(session->server);
     SDL_DestroyCond(session->cond);
     SDL_DestroyMutex(session->mutex);
     SDL_DestroyMutex(session->state_lock);
+    free(session->config.microphone_device);
     free(session->app_name);
     free(session);
 }
@@ -261,8 +264,10 @@ void session_config_init(app_t *app, session_config_t *config, const SERVER_DATA
     config->vmouse = app_config->virtual_mouse;
     config->hardware_mouse = app_config->hardware_mouse;
     config->local_audio = app_config->localaudio;
+    config->microphone_device = app_config->microphone_device != NULL ? strdup(app_config->microphone_device) : NULL;
     config->view_only = app_config->viewonly;
     config->sops = app_config->sops;
+    config->stream.enableMic = app_config->enable_microphone;
     if (app_config->stick_deadzone < 0) {
         config->stick_deadzone = 0;
     } else if (app_config->stick_deadzone > 100) {
@@ -336,6 +341,9 @@ void session_config_init(app_t *app, session_config_t *config, const SERVER_DATA
         config->stream.bitrate = (int) ((int64_t) config->stream.bitrate * 125 / 100);
     }
     config->stream.encryptionFlags = ENCFLG_AUDIO;
+    if (config->stream.enableMic) {
+        config->stream.encryptionFlags |= ENCFLG_MICROPHONE;
+    }
 }
 
 /**

--- a/src/app/stream/session.h
+++ b/src/app/stream/session.h
@@ -62,6 +62,7 @@ typedef struct session_config_t {
     bool sops;
     bool view_only;
     bool local_audio;
+    char *microphone_device;
     bool hardware_mouse;
     bool vmouse;
     uint8_t stick_deadzone;

--- a/src/app/stream/session_priv.h
+++ b/src/app/stream/session_priv.h
@@ -10,6 +10,7 @@
 #include "embed_wrapper.h"
 
 typedef struct app_t app_t;
+typedef struct microphone_capture_t microphone_capture_t;
 
 struct session_t {
     session_config_t config;
@@ -37,6 +38,7 @@ struct session_t {
     SDL_mutex *mutex;
     SDL_Thread *thread;
     SS4S_Player *player;
+    microphone_capture_t *microphone_capture;
 };
 
 void session_set_state(session_t *session, STREAMING_STATE state);

--- a/src/app/stream/session_worker.c
+++ b/src/app/stream/session_worker.c
@@ -7,6 +7,7 @@
 #include "util/user_event.h"
 #include "input/input_gamepad.h"
 #include "stream/connection/session_connection.h"
+#include "stream/audio/microphone_capture.h"
 #include "stream/audio/session_audio.h"
 #include "stream/video/session_video.h"
 #include "app_session.h"
@@ -90,6 +91,21 @@ int session_worker(session_t *session) {
         commons_log_error("Session", "Failed to start connection: Limelight returned %d", startResult);
         goto thread_cleanup;
     }
+
+    if (session->config.stream.enableMic) {
+        if (LiIsMicrophoneStreamActive()) {
+            session->microphone_capture = microphone_capture_create(session->config.microphone_device);
+            if (session->microphone_capture == NULL || !microphone_capture_start(session->microphone_capture)) {
+                commons_log_warn("Session", "Client microphone capture initialization failed after negotiation");
+                microphone_capture_destroy(session->microphone_capture);
+                session->microphone_capture = NULL;
+            }
+        } else {
+            commons_log_info("Session",
+                             "Host did not negotiate microphone streaming; leaving client microphone disabled");
+        }
+    }
+
     session_set_state(session, STREAMING_STREAMING);
     bus_pushevent(USER_STREAM_OPEN, NULL, NULL);
     SDL_LockMutex(session->mutex);
@@ -101,6 +117,8 @@ int session_worker(session_t *session) {
     bus_pushevent(USER_STREAM_CLOSE, NULL, NULL);
 
     session_set_state(session, STREAMING_DISCONNECTING);
+    microphone_capture_destroy(session->microphone_capture);
+    session->microphone_capture = NULL;
     LiStopConnection();
 
     if (session->quitapp) {
@@ -117,6 +135,8 @@ int session_worker(session_t *session) {
     // Don't always reset status as error state should be kept
     session_set_state(session, STREAMING_NONE);
     thread_cleanup:
+    microphone_capture_destroy(session->microphone_capture);
+    session->microphone_capture = NULL;
     session_connection_callbacks_reset(session);
     if (session->player != NULL) {
         SS4S_PlayerClose(session->player);

--- a/src/app/ui/settings/panes/audio.pane.c
+++ b/src/app/ui/settings/panes/audio.pane.c
@@ -9,6 +9,8 @@
 #include "ss4s.h"
 #include "ss4s_modules.h"
 
+#include <SDL.h>
+
 typedef struct audio_pane_t {
     lv_fragment_t base;
     settings_controller_t *parent;
@@ -17,6 +19,8 @@ typedef struct audio_pane_t {
 
     pref_dropdown_string_entry_t *adec_entries;
     int adec_entries_len;
+    pref_dropdown_string_entry_t *mic_entries;
+    int mic_entries_len;
 
     pref_dropdown_int_entry_t surround_entries[3];
     int surround_entries_len;
@@ -31,6 +35,8 @@ static void pane_ctor(lv_fragment_t *self, void *args);
 static void pane_dtor(lv_fragment_t *self);
 
 static void module_changed_cb(lv_event_t *e);
+
+static void microphone_checkbox_changed_cb(lv_event_t *e);
 
 const lv_fragment_class_t settings_pane_audio_cls = {
     .constructor_cb = pane_ctor,
@@ -76,11 +82,38 @@ static void pane_ctor(lv_fragment_t *self, void *args) {
         entry->fallback = config.configuration == AUDIO_CONFIGURATION_STEREO;
         pane->surround_entries_len++;
     }
+
+    const bool audio_was_initialized = SDL_WasInit(SDL_INIT_AUDIO) != 0;
+    int microphone_device_count = 0;
+    if (audio_was_initialized || SDL_InitSubSystem(SDL_INIT_AUDIO) == 0) {
+        microphone_device_count = SDL_GetNumAudioDevices(SDL_TRUE);
+    }
+
+    pane->mic_entries = calloc((size_t) microphone_device_count + 2, sizeof(pref_dropdown_string_entry_t));
+    set_decoder_entry(&pane->mic_entries[pane->mic_entries_len++], locstr("Default system microphone"), "", true);
+    for (int i = 0; i < microphone_device_count; i++) {
+        const char *name = SDL_GetAudioDeviceName(i, SDL_TRUE);
+        if (name == NULL || name[0] == '\0' || contains_decoder_group(pane->mic_entries, pane->mic_entries_len, name)) {
+            continue;
+        }
+        set_decoder_entry(&pane->mic_entries[pane->mic_entries_len++], name, name, false);
+    }
+    if (app_configuration->microphone_device != NULL &&
+        app_configuration->microphone_device[0] != '\0' &&
+        !contains_decoder_group(pane->mic_entries, pane->mic_entries_len, app_configuration->microphone_device)) {
+        set_decoder_entry(&pane->mic_entries[pane->mic_entries_len++], app_configuration->microphone_device,
+                          app_configuration->microphone_device, false);
+    }
+
+    if (!audio_was_initialized && SDL_WasInit(SDL_INIT_AUDIO) != 0) {
+        SDL_QuitSubSystem(SDL_INIT_AUDIO);
+    }
 }
 
 static void pane_dtor(lv_fragment_t *self) {
     audio_pane_t *pane = (audio_pane_t *) self;
     free(pane->adec_entries);
+    free(pane->mic_entries);
 }
 
 static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
@@ -115,8 +148,25 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
                                               &app_configuration->stream.audioConfiguration, NULL);
     lv_obj_set_width(ch_dropdown, LV_PCT(100));
 
-    lv_obj_add_event_cb(adec_dropdown, module_changed_cb, LV_EVENT_VALUE_CHANGED, controller);
+    pref_header(view, locstr("Microphone Settings"));
 
+    lv_obj_t *mic_checkbox = pref_checkbox(view, locstr("Enable microphone streaming"),
+                                           &app_configuration->enable_microphone, false);
+    pref_desc_label(view, locstr("Streams local microphone audio to the host when microphone passthrough is available."),
+                    false);
+
+    pref_title_label(view, locstr("Microphone input"));
+    lv_obj_t *mic_dropdown = pref_dropdown_string(view, controller->mic_entries, controller->mic_entries_len,
+                                                  &app_configuration->microphone_device);
+    lv_obj_set_width(mic_dropdown, LV_PCT(100));
+    if (!app_configuration->enable_microphone) {
+        lv_obj_add_state(mic_dropdown, LV_STATE_DISABLED);
+    }
+    pref_desc_label(view, locstr("Choose which local microphone Moonlight captures. Leave this on the default option to follow the system input device."),
+                    false);
+
+    lv_obj_add_event_cb(adec_dropdown, module_changed_cb, LV_EVENT_VALUE_CHANGED, controller);
+    lv_obj_add_event_cb(mic_checkbox, microphone_checkbox_changed_cb, LV_EVENT_VALUE_CHANGED, mic_dropdown);
     return view;
 }
 
@@ -130,4 +180,13 @@ static void module_changed_cb(lv_event_t *e) {
     settings_controller_t *parent = fragment->parent;
     parent->needs_restart = true;
     update_conflict_hint(parent->app, fragment->conflict_hint);
+}
+
+static void microphone_checkbox_changed_cb(lv_event_t *e) {
+    lv_obj_t *dropdown = (lv_obj_t *) lv_event_get_user_data(e);
+    if (app_configuration->enable_microphone) {
+        lv_obj_clear_state(dropdown, LV_STATE_DISABLED);
+    } else {
+        lv_obj_add_state(dropdown, LV_STATE_DISABLED);
+    }
 }


### PR DESCRIPTION
Add client microphone streaming support

## What This Does
This ports client-to-host microphone passthrough support into `moonlight-tv` so the client can capture local microphone input, encode it as timed Opus voice packets, and send it to the host when microphone streaming is negotiated.

Specifically, this PR:
- adds persisted microphone settings and input-device selection in the audio settings pane
- adds an SDL microphone capture path with Opus encoding and timed packet delivery during active stream sessions
- wires microphone negotiation and encryption flags into the stream configuration
- updates `core/moonlight-common-c` to the microphone-capable revision required for this feature

## Intended Usage
This is intended to be used with my Apollo fork and the related Apollo upstream work:
- Apollo fork: [logabell/Apollo](https://github.com/logabell/Apollo)
- Apollo upstream PR: [ClassicOldSong/Apollo#1428](https://github.com/ClassicOldSong/Apollo/pull/1428)
- Moonlight reference fork: [logabell/moonlight-qt-mic](https://github.com/logabell/moonlight-qt-mic)

This `moonlight-tv` PR is meant to complement that Apollo work so microphone passthrough can be used end-to-end with the Apollo fork.

## Context
This PR was submitted at the request of community member `LightningJC`.

## Notes
- The submodule URL changes because upstream `moonlight-common-c` does not yet contain the microphone APIs used here.

## Verification
- `git diff --check`
- attempted `cmake -S . -B build` on Windows, but configuration stops immediately because `pkg-config` is not installed in this environment
