### PR TITLE
ci(webos): restrict ares-package and toolbox download to amd64 .deb

### DIFF
--- a/.github/workflows/build-webos.yml
+++ b/.github/workflows/build-webos.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: "webosbrew/ares-cli-rs"
           latest: true
-          fileName: "ares-package_*.deb"
+          fileName: "ares-package_*_amd64.deb"
           out-file-path: "temp"
 
       - name: Download Homebrew Toolbox
@@ -40,7 +40,7 @@ jobs:
         with:
           repository: "webosbrew/dev-toolbox-cli"
           latest: true
-          fileName: "webosbrew-toolbox-*.deb"
+          fileName: "webosbrew-toolbox-*_amd64.deb"
           out-file-path: "temp"
 
       - name: Update Packages


### PR DESCRIPTION
webosbrew/ares-cli-rs now publishes both _amd64 and _arm64 release artifacts. The fileName glob pattern matched both, so "sudo apt-get install ./temp/*.deb" tried to install both architectures on the amd64 GitHub runner and failed with:

  ares-package     : Conflicts: ares-package:arm64 but 0.1.4-1 is to be installed
  ares-package:arm64 : Depends: libc6:arm64 (>= 2.34) but it is not installable

Pin the download glob to "*_amd64.deb" for both ares-package and the webosbrew toolbox so only the runner-native package is fetched. The toolbox doesn't currently publish arm64 but match the same pattern for consistency in case it ever does.

If the build moves to an arm64 runner in the future, this needs to be templated on ${{ runner.arch }}.