### PR TITLE
fix: restore Full Range YUV toggle with correct HDR handling, translate build scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ else ()
         set(MOONLIGHT_VERSION "0.0.0")
     endif ()
 endif ()
-set(MOONLIGHT_VERSION "1.0.4")
+set(MOONLIGHT_VERSION "1.0.5")
 
 project(moonlight VERSION ${MOONLIGHT_VERSION} LANGUAGES C)
 

--- a/deploy/webos/appinfo.json
+++ b/deploy/webos/appinfo.json
@@ -10,7 +10,7 @@
     "largeIcon": "icon_large.png",
     "splashBackground": "splash.png",
     "dialAppName": "Aurora",
-    "appDescription": "Aurora — cliente GameStream para LG webOS (fork do Moonlight TV). Transmite do PC com Sunshine ou NVIDIA GameStream em até 4K 120 HDR.",
+    "appDescription": "Aurora \u2014 GameStream client for LG webOS. Stream from your PC with Sunshine or NVIDIA GameStream at up to 4K 120Hz HDR.",
     "supportTouchMode": "full",
     "useAllMouseButtons": true,
     "cloudgame_active": true

--- a/scripts/webos/Dockerfile.build
+++ b/scripts/webos/Dockerfile.build
@@ -1,4 +1,4 @@
-# Dockerfile para build do Moonlight TV para webOS (LG C1)
+# Dockerfile for building Aurora for webOS
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -14,5 +14,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /build
 
-# O código fonte será montado como volume
+# Source code will be mounted as a volume
 # SDK será baixado durante o build

--- a/scripts/webos/build_for_lg.ps1
+++ b/scripts/webos/build_for_lg.ps1
@@ -1,10 +1,10 @@
-# Build Moonlight TV para LG webOS (LG C1) - PowerShell launcher para WSL
-# Execute este script no Windows para compilar via WSL
+# Build Aurora for LG webOS - PowerShell launcher for WSL
+# Run this script on Windows to compile via WSL
 
 $ErrorActionPreference = "Stop"
 $ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 
-Write-Host "=== Moonlight TV - Build para LG C1 (webOS) ===" -ForegroundColor Cyan
+Write-Host "=== Aurora - Build for LG webOS ===" -ForegroundColor Cyan
 Write-Host ""
 
 # Verificar WSL
@@ -12,14 +12,14 @@ $wslTest = wsl -e bash -c "echo ok" 2>$null
 if ($LASTEXITCODE -ne 0 -or $wslTest -ne "ok") {
     Write-Host "ERRO: WSL nao encontrado ou nao configurado." -ForegroundColor Red
     Write-Host ""
-    Write-Host "Para instalar o WSL com Ubuntu:" -ForegroundColor Yellow
+    Write-Host "To install WSL with Ubuntu:" -ForegroundColor Yellow
     Write-Host "  wsl --install -d Ubuntu" -ForegroundColor White
     Write-Host ""
-    Write-Host "Apos instalar, reinicie o computador e execute este script novamente." -ForegroundColor Yellow
+    Write-Host "After installing, restart your computer and run this script again." -ForegroundColor Yellow
     exit 1
 }
 
-# Converter caminho Windows para WSL
+# Convert Windows path to WSL
 $WslPath = wsl -e wslpath -a $ProjectRoot
 
 Write-Host "Projeto: $ProjectRoot" -ForegroundColor Gray
@@ -38,10 +38,10 @@ chmod +x scripts/webos/build_for_lg.sh
 
 if ($LASTEXITCODE -eq 0) {
     Write-Host ""
-    Write-Host "=== Build concluido com sucesso! ===" -ForegroundColor Green
+    Write-Host "=== Build completed successfully! ===" -ForegroundColor Green
     Write-Host "Pacote IPK em: $ProjectRoot\dist\" -ForegroundColor Cyan
 } else {
     Write-Host ""
-    Write-Host "Build falhou. Verifique os erros acima." -ForegroundColor Red
+    Write-Host "Build failed. Check the errors above." -ForegroundColor Red
     exit 1
 }

--- a/scripts/webos/build_for_lg.sh
+++ b/scripts/webos/build_for_lg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Build Moonlight TV for LG webOS (compatível com LG C1 e outras TVs webOS)
-# Requer: Linux ou WSL2 com Ubuntu
+# Build Aurora for LG webOS (compatible with LG C1 and other webOS TVs)
+# Requires: Linux or WSL2 with Ubuntu
 
 set -e
 
@@ -14,34 +14,34 @@ SDK_DIR="${WEBOS_SDK_DIR:-/tmp/arm-webos-linux-gnueabi_sdk-buildroot}"
 
 cd "${PROJECT_ROOT}"
 
-echo "=== Moonlight TV - Build para LG webOS (LG C1, etc.) ==="
-echo "Projeto: ${PROJECT_ROOT}"
+echo "=== Aurora - Build for LG webOS ==="
+echo "Project: ${PROJECT_ROOT}"
 echo "Build type: ${BUILD_TYPE}"
 echo ""
 
-# Verificar se estamos no diretório correto
+# Check we are in the project root
 if [ ! -f "scripts/webos/easy_build.sh" ]; then
-    echo "Erro: Execute este script na raiz do projeto moonlight-tv"
+    echo "Error: Run this script from the project root"
     exit 1
 fi
 
-# Verificar dependências
+# Check dependencies
 for cmd in cmake awk gawk; do
     if ! command -v $cmd &>/dev/null; then
-        echo "Erro: $cmd não encontrado. Instale com: sudo apt-get install cmake gawk"
+        echo "Error: $cmd not found. Install with: sudo apt-get install cmake gawk"
         exit 1
     fi
 done
 
-# Inicializar submodules
-echo "Atualizando submodules..."
+# Initialize submodules
+echo "Updating submodules..."
 git submodule update --init --recursive
 
-# Baixar e configurar webOS SDK se não existir
+# Download and configure webOS SDK if not present
 if [ ! -f "${SDK_DIR}/share/buildroot/toolchainfile.cmake" ]; then
     echo ""
-    echo "WebOS SDK não encontrado em ${SDK_DIR}"
-    echo "Baixando SDK (buildroot-nc4 ${SDK_VERSION})..."
+    echo "WebOS SDK not found at ${SDK_DIR}"
+    echo "Downloading SDK (buildroot-nc4 ${SDK_VERSION})..."
     
     mkdir -p /tmp
     cd /tmp
@@ -52,47 +52,47 @@ if [ ! -f "${SDK_DIR}/share/buildroot/toolchainfile.cmake" ]; then
         elif command -v wget &>/dev/null; then
             wget "${SDK_URL}"
         else
-            echo "Erro: curl ou wget necessário para baixar o SDK"
+            echo "Error: curl or wget required to download the SDK"
             exit 1
         fi
     fi
     
-    echo "Extraindo SDK..."
+    echo "Extracting SDK..."
     tar -xzf "${SDK_ARCHIVE}"
     
     if [ -d "arm-webos-linux-gnueabi_sdk-buildroot" ]; then
-        echo "Relocando SDK..."
+        echo "Relocating SDK..."
         ./arm-webos-linux-gnueabi_sdk-buildroot/relocate-sdk.sh
         SDK_DIR="/tmp/arm-webos-linux-gnueabi_sdk-buildroot"
     else
-        echo "Erro: Estrutura do SDK inesperada após extração"
+        echo "Error: Unexpected SDK structure after extraction"
         exit 1
     fi
     
     cd "${PROJECT_ROOT}"
 else
-    echo "WebOS SDK encontrado em ${SDK_DIR}"
+    echo "WebOS SDK found at ${SDK_DIR}"
 fi
 
 TOOLCHAIN_FILE="${SDK_DIR}/share/buildroot/toolchainfile.cmake"
 
 if [ ! -f "${TOOLCHAIN_FILE}" ]; then
-    echo "Erro: Toolchain não encontrado em ${TOOLCHAIN_FILE}"
+    echo "Error: Toolchain not found at ${TOOLCHAIN_FILE}"
     exit 1
 fi
 
 echo ""
-echo "Executando build..."
+echo "Running build..."
 export TOOLCHAIN_FILE
 ./scripts/webos/easy_build.sh -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
 
 echo ""
-echo "=== Build concluído! ==="
-echo "Pacote IPK gerado em: ${PROJECT_ROOT}/dist/"
+echo "=== Build complete! ==="
+echo "IPK package generated at: ${PROJECT_ROOT}/dist/"
 ls -la "${PROJECT_ROOT}/dist/"/*.ipk 2>/dev/null || true
 echo ""
-echo "Para instalar na LG C1:"
-echo "  1. Instale o webosbrew e dev-manager na TV"
-echo "  2. Use: ares-install dist/com.aurora.gamestream_*_arm.ipk -d <IP_DA_TV>"
-echo "  Ou use o dev-manager-desktop para instalação fácil"
+echo "To install on your TV:"
+echo "  1. Install webosbrew and dev-manager on the TV"
+echo "  2. Use: ares-install dist/com.aurora.gamestream_*_arm.ipk -d <TV_IP>"
+echo "  Or use webOS Dev Manager for easy installation"
 echo ""

--- a/scripts/webos/build_with_docker.ps1
+++ b/scripts/webos/build_with_docker.ps1
@@ -1,10 +1,10 @@
-# Build Moonlight TV para LG C1 via Docker
+# Build Aurora for LG webOS via Docker
 # Funciona no Windows sem WSL Ubuntu - usa container Ubuntu
 
 $ErrorActionPreference = "Stop"
 $ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 
-Write-Host "=== Moonlight TV - Build para LG C1 (via Docker) ===" -ForegroundColor Cyan
+Write-Host "=== Aurora - Build for LG webOS (via Docker) ===" -ForegroundColor Cyan
 Write-Host ""
 
 # Verificar Docker
@@ -22,12 +22,12 @@ if (-not $dockerOk) {
     exit 1
 }
 
-Write-Host "Usando Docker para build em ambiente Ubuntu..." -ForegroundColor Green
+Write-Host "Using Docker to build in Ubuntu environment..." -ForegroundColor Green
 Write-Host ""
 
-# Montar o projeto e executar o build
+# Mount the project and run the build
 $ScriptPath = Join-Path $PSScriptRoot "docker_build_inner.sh"
-# sed remove CRLF (Windows) para funcionar no Linux
+# sed removes CRLF (Windows line endings) for Linux compatibility
 docker run --rm -v "${ProjectRoot}:/build" -v "${ScriptPath}:/docker_build.sh" -w /build ubuntu:22.04 bash -c "sed 's/\r$//' /docker_build.sh | bash"
 
 if ($LASTEXITCODE -eq 0) {
@@ -37,6 +37,6 @@ if ($LASTEXITCODE -eq 0) {
     Get-ChildItem "$ProjectRoot\dist\*.ipk" -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "  $($_.Name)" }
 } else {
     Write-Host ""
-    Write-Host "Build falhou." -ForegroundColor Red
+    Write-Host "Build failed." -ForegroundColor Red
     exit 1
 }

--- a/scripts/webos/docker_build_inner.sh
+++ b/scripts/webos/docker_build_inner.sh
@@ -3,12 +3,12 @@ set -e
 
 apt-get update -qq && apt-get install -y -qq cmake gawk curl git build-essential ca-certificates wget file > /dev/null
 
-# Instalar ares-package (necessario para gerar o IPK webOS)
-echo "Instalando ares-package..."
+# Install ares-package (required to generate the webOS IPK)
+echo "Installing ares-package..."
 cd /tmp
 wget -q https://github.com/webosbrew/ares-cli-rs/releases/download/20241111-d97ba96/ares-package_0.1.4-1_amd64.deb
 apt-get install -y -qq ./ares-package_0.1.4-1_amd64.deb 2>/dev/null || (dpkg -i ares-package_0.1.4-1_amd64.deb && apt-get -f install -y -qq)
-which ares-package || { echo "Erro: ares-package nao instalado"; exit 1; }
+which ares-package || { echo "Error: ares-package not installed"; exit 1; }
 
 cd /build
 # Windows bind mounts can leave stale git submodule lock files in .git/modules.
@@ -20,7 +20,7 @@ rm -rf build/webos-easy_build
 # Download SDK
 cd /tmp
 if [ ! -f arm-webos-linux-gnueabi_sdk-buildroot.tar.gz ]; then
-    echo "Baixando webOS SDK..."
+    echo "Downloading webOS SDK..."
     curl -sL -O https://github.com/openlgtv/buildroot-nc4/releases/download/webos-b17b4cc/arm-webos-linux-gnueabi_sdk-buildroot.tar.gz
 fi
 tar -xzf arm-webos-linux-gnueabi_sdk-buildroot.tar.gz
@@ -30,11 +30,11 @@ cd /build
 SDK_ROOT=/tmp/arm-webos-linux-gnueabi_sdk-buildroot
 export TOOLCHAIN_FILE="${SDK_ROOT}/share/buildroot/toolchainfile.cmake"
 if [ ! -f "${TOOLCHAIN_FILE}" ]; then
-  echo "Erro: toolchain nao encontrado: ${TOOLCHAIN_FILE}"
+  echo "Error: toolchain not found: ${TOOLCHAIN_FILE}"
   exit 1
 fi
 if [ ! -x "${SDK_ROOT}/bin/arm-webos-linux-gnueabi-gcc" ]; then
-  echo "Erro: compilador webOS nao encontrado: ${SDK_ROOT}/bin/arm-webos-linux-gnueabi-gcc"
+  echo "Error: webOS compiler not found: ${SDK_ROOT}/bin/arm-webos-linux-gnueabi-gcc"
   exit 1
 fi
 CI=1 ./scripts/webos/easy_build.sh -DCMAKE_BUILD_TYPE=Release

--- a/src/app/app_settings.c
+++ b/src/app/app_settings.c
@@ -49,7 +49,7 @@ void settings_initialize(app_settings_t *config, char *conf_dir) {
     config->stream.audioConfiguration = AUDIO_CONFIGURATION_STEREO;
 
     config->debug_level = 0;
-    set_string(&config->language, "pt-BR");
+    set_string(&config->language, "auto");
     set_string(&config->audio_backend, "auto");
     set_string(&config->decoder, "auto");
     config->audio_device = NULL;
@@ -68,6 +68,7 @@ void settings_initialize(app_settings_t *config, char *conf_dir) {
     config->absmouse = true;
     config->virtual_mouse = false;
     config->hdr = false;
+    config->force_full_color_range = false;
     config->video_tight_sync = false;
     config->hevc = true;
     config->av1 = false;
@@ -125,6 +126,7 @@ bool settings_save(app_settings_t *config) {
     ini_write_section(fp, "video");
     ini_write_string(fp, "decoder", config->decoder);
     ini_write_bool(fp, "hdr", config->hdr);
+    ini_write_bool(fp, "force_full_color_range", config->force_full_color_range);
     ini_write_bool(fp, "tight_display_sync", config->video_tight_sync);
     ini_write_bool(fp, "hevc", config->hevc);
     ini_write_bool(fp, "av1", config->av1);
@@ -242,7 +244,7 @@ static int settings_parse(app_settings_t *config, const char *section, const cha
             config->client_refresh_rate_x100 = 24000;
         }
     } else if (INI_FULL_MATCH("video", "force_full_color_range")) {
-        /* Legacy: full range is enabled automatically when HDR is on. */
+        config->force_full_color_range = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("surround")) {
         config->stream.audioConfiguration = parse_audio_config(value);
     } else if (INI_NAME_MATCH("sops")) {

--- a/src/app/app_settings.h
+++ b/src/app/app_settings.h
@@ -48,6 +48,7 @@ typedef struct app_settings_t {
     bool swap_abxy;
     bool syskey_capture;
     bool hdr;   /* HDR10 (PQ) over HEVC Main10 or AV1 Main10 when host and decoder support it */
+    bool force_full_color_range; /* SDR only: request full-range YUV (0-255) from host. No effect when HDR is on. */
     /**
      * webOS Starfish: nominal-frame PTS pacing + fixed small negative presentation offset
      * for tighter vsync without adding latency when the stream runs late.

--- a/src/app/stream/session.c
+++ b/src/app/stream/session.c
@@ -326,7 +326,10 @@ void session_config_init(app_t *app, session_config_t *config, const SERVER_DATA
         config->stream.colorSpace = COLORSPACE_REC_601;
     }
     /* Full range (0–255) when HDR is on, like Moonlight Android; SDR uses limited range. */
-    config->stream.colorRange = app_config->hdr ? COLOR_RANGE_FULL : COLOR_RANGE_LIMITED;
+    /* HDR10 (PQ/SMPTE ST 2084) always uses limited range by standard.
+     * For SDR, honor force_full_color_range if the user has enabled it. */
+    config->stream.colorRange = (!app_config->hdr && app_config->force_full_color_range)
+        ? COLOR_RANGE_FULL : COLOR_RANGE_LIMITED;
     if (app_config->client_refresh_rate_x100 > 0) {
         config->stream.clientRefreshRateX100 = app_config->client_refresh_rate_x100;
     }

--- a/src/app/ui/settings/panes/video.pane.c
+++ b/src/app/ui/settings/panes/video.pane.c
@@ -132,6 +132,14 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     lv_obj_add_event_cb(hdr_checkbox, hdr_state_update_cb, LV_EVENT_VALUE_CHANGED, controller);
     lv_obj_add_event_cb(hdr_more, hdr_more_click_cb, LV_EVENT_CLICKED, NULL);
 
+    pref_header(view, locstr("Color"));
+    pref_checkbox(view, locstr("Full range YUV (SDR only)"), &app_configuration->force_full_color_range, false);
+    pref_desc_label(view,
+                    locstr("Request full-range (0-255) color from the host for SDR streams. "
+                           "Has no effect when HDR is enabled — HDR always uses limited range "
+                           "(SMPTE ST 2084 standard). Disable if SDR colors look washed out."),
+                    false);
+
 #if TARGET_WEBOS
     pref_header(view, locstr("Smooth playback (TV)"));
     lv_obj_t *tight_cb =
@@ -180,7 +188,7 @@ static void hdr_state_update(video_pane_t *controller) {
         lv_obj_clear_state(controller->hdr_checkbox, LV_STATE_DISABLED);
         lv_label_set_text(controller->hdr_hint,
                           locstr("HDR10 (PQ) when the host streams HDR (HEVC Main10 or AV1 Main10). "
-                                 "Enabling HDR also uses the full video color range (Android-style)."));
+                                 "HDR always uses limited color range (SMPTE ST 2084 standard)."));
     }
 }
 


### PR DESCRIPTION
Closes #12, closes #15.

**HDR fix:** Restores the `force_full_color_range` / Full Range YUV toggle that was removed in v1.0.4, but with a key correction: HDR is now immune to the toggle. HDR10 (PQ/SMPTE ST 2084) always uses limited range by standard, forcing `COLOR_RANGE_FULL` for HDR caused the washed-out colors and grey blacks reported in #12. The toggle now only affects SDR streams and defaults to off.

This also explains the earlier workaround: in v1.0.3, turning off "Full Range YUV" fixed it by setting `COLOR_RANGE_LIMITED` globally. In v1.0.4 the option was removed and the behavior was hardcoded the wrong way.

**Cleanup:** Translates all Portuguese strings in the build scripts and app description to English (#15). Regarding the repo rename to Aurora: that's a GitHub settings change only the owner can make.