### PR TITLE
launcher: optional auto-resume of a running app on start

### DIFF
--- a/src/app/app_settings.c
+++ b/src/app/app_settings.c
@@ -63,6 +63,7 @@ void settings_initialize(app_settings_t *config, char *conf_dir) {
     // TODO make this automatic
     config->unsupported = true;
     config->quitappafter = false;
+    config->autoresume = false;
     config->viewonly = false;
     config->rotate = 0;
     config->absmouse = true;
@@ -113,6 +114,7 @@ bool settings_save(app_settings_t *config) {
     ini_write_bool(fp, "sops", config->sops);
     ini_write_bool(fp, "localaudio", config->localaudio);
     ini_write_bool(fp, "quitappafter", config->quitappafter);
+    ini_write_bool(fp, "autoresume", config->autoresume);
     ini_write_bool(fp, "viewonly", config->viewonly);
 
     ini_write_section(fp, "input");
@@ -257,6 +259,8 @@ static int settings_parse(app_settings_t *config, const char *section, const cha
         config->localaudio = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("quitappafter")) {
         config->quitappafter = INI_IS_TRUE(value);
+    } else if (INI_NAME_MATCH("autoresume")) {
+        config->autoresume = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("viewonly")) {
         config->viewonly = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("absmouse")) {

--- a/src/app/app_settings.h
+++ b/src/app/app_settings.h
@@ -41,6 +41,7 @@ typedef struct app_settings_t {
     int rotate;
     bool unsupported;
     bool quitappafter;
+    bool autoresume;
     bool viewonly;
     bool absmouse;
     bool hardware_mouse;

--- a/src/app/ui/launcher/launcher.controller.c
+++ b/src/app/ui/launcher/launcher.controller.c
@@ -57,6 +57,8 @@ static void open_help(lv_event_t *event);
 
 static void select_pc(launcher_fragment_t *controller, const uuidstr_t *uuid);
 
+static void launcher_try_auto_resume(launcher_fragment_t *controller, const uuidstr_t *uuid);
+
 /* Switch the active focus group between top-bar and detail (game rail).
  * Replaces the old "set_detail_opened" semantics now that both areas are visible
  * simultaneously - we just route input to whichever group the user is in. */
@@ -247,10 +249,10 @@ void on_pc_added(const uuidstr_t *uuid, void *userdata) {
 }
 
 void on_pc_updated(const uuidstr_t *uuid, void *userdata) {
-    LV_UNUSED(uuid);
     launcher_fragment_t *controller = userdata;
     /* Hostname can change after a successful query; keep the top-bar label in sync. */
     launcher_refresh_server_label(controller);
+    launcher_try_auto_resume(controller, uuid);
 }
 
 void on_pc_removed(const uuidstr_t *uuid, void *userdata) {
@@ -272,12 +274,50 @@ static void select_pc(launcher_fragment_t *controller, const uuidstr_t *uuid) {
             controller->def_app_requested = true;
             arg.def_app = params->default_app_id;
         }
+        if (controller->pending_def_app != 0) {
+            arg.def_app = controller->pending_def_app;
+            controller->pending_def_app = 0;
+        }
         lv_fragment_t *fragment = lv_fragment_create(&apps_controller_class, &arg);
         lv_fragment_manager_replace(controller->base.child_manager, fragment, &controller->detail);
         pcmanager_select(pcmanager, uuid);
     } else {
         lv_fragment_manager_pop(controller->base.child_manager);
     }
+}
+
+static void launcher_auto_resume_async(void *userdata) {
+    launcher_fragment_t *controller = userdata;
+    // The launcher may have been destroyed between scheduling and firing.
+    if (current_instance != controller) { return; }
+    const uuidstr_t *uuid = &controller->auto_resume_uuid;
+    const pclist_t *node = pcmanager_node(pcmanager, uuid);
+    if (node == NULL || node->state.code != SERVER_STATE_AVAILABLE) { return; }
+    int current = pcmanager_node_current_app(node);
+    if (current == 0) { return; }
+    commons_log_info("UI", "Auto-resuming running app %d on host %s", current, node->server->hostname);
+    // Inject the running app as def_app; apps.controller's def_app auto-launch
+    // path resumes it (gs_start_app resumes when appId == currentGame).
+    controller->pending_def_app = current;
+    select_pc(controller, uuid);
+}
+
+static void launcher_try_auto_resume(launcher_fragment_t *controller, const uuidstr_t *uuid) {
+    if (!app_configuration->autoresume) { return; }
+    // Only fire once per app start; let an explicit CLI/deep-link launch take priority.
+    if (controller->auto_resume_done || controller->def_app_requested) { return; }
+    const pclist_t *node = pcmanager_node(pcmanager, uuid);
+    if (node == NULL || node->state.code != SERVER_STATE_AVAILABLE) { return; }
+    if (pcmanager_node_current_app(node) == 0) { return; }
+    // Set the guard immediately so repeated host updates (incl. the refresh after a
+    // stream ends, when currentGame is still set) can neither re-trigger nor
+    // double-schedule the resume.
+    controller->auto_resume_done = true;
+    controller->auto_resume_uuid = *uuid;
+    // Defer the actual host select: select_pc() replaces the apps fragment, whose
+    // teardown unregisters a pcmanager listener — unsafe while iterating listeners
+    // inside the notify() that called us.
+    lv_async_call(launcher_auto_resume_async, controller);
 }
 
 static void cb_detail_focused(lv_event_t *event) {

--- a/src/app/ui/launcher/launcher.controller.h
+++ b/src/app/ui/launcher/launcher.controller.h
@@ -50,6 +50,9 @@ typedef struct launcher_fragment_t {
     const app_launch_params_t *launch_params;
     bool def_host_selected;
     bool def_app_requested;
+    bool auto_resume_done;        // once-guard: only auto-resume once per app start
+    int  pending_def_app;         // def_app id injected into the next select_pc()
+    uuidstr_t auto_resume_uuid;   // host scheduled for deferred auto-resume
 
     /* Full-screen overlay over the game area (below the top bar). Hosts embedded Settings. */
     lv_obj_t *settings_layer;


### PR DESCRIPTION
Adds an opt-in autoresume setting (default off). When the host already has a
running game on app start, resume straight into it instead of stopping at the
app grid. Implemented by injecting the running appId as def_app so the existing
def_app auto-launch path resumes it (gs_start_app resumes when appId ==
currentGame). Once-guarded per app start and deferred via lv_async_call to avoid
re-entrant pcmanager listener teardown; an explicit CLI/deep-link launch takes
priority.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

