### PR TITLE
hid_passthrough: auto-plug recognized controllers on stream start + hotplug

### DIFF
--- a/src/app/app_settings.c
+++ b/src/app/app_settings.c
@@ -78,6 +78,7 @@ void settings_initialize(app_settings_t *config, char *conf_dir) {
     config->client_refresh_rate_x100 = 0;
     config->hid_passthrough = false;
     config->hid_passthrough_port = 48054;
+    config->hid_passthrough_autoplug = true;
 
     config->conf_dir = conf_dir;
     config->ini_path = path_join(conf_dir, CONF_NAME_MOONLIGHT);
@@ -126,6 +127,7 @@ bool settings_save(app_settings_t *config) {
     ini_write_bool(fp, "syskey_capture", config->syskey_capture);
     ini_write_bool(fp, "hid_passthrough", config->hid_passthrough);
     ini_write_int(fp, "hid_passthrough_port", config->hid_passthrough_port);
+    ini_write_bool(fp, "hid_passthrough_autoplug", config->hid_passthrough_autoplug);
 
     ini_write_section(fp, "video");
     ini_write_string(fp, "decoder", config->decoder);
@@ -280,6 +282,8 @@ static int settings_parse(app_settings_t *config, const char *section, const cha
         config->syskey_capture = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("hid_passthrough")) {
         config->hid_passthrough = INI_IS_TRUE(value);
+    } else if (INI_NAME_MATCH("hid_passthrough_autoplug")) {
+        config->hid_passthrough_autoplug = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("hid_passthrough_port")) {
         set_int(&config->hid_passthrough_port, value);
         if (config->hid_passthrough_port <= 0 || config->hid_passthrough_port > 65535) {

--- a/src/app/app_settings.h
+++ b/src/app/app_settings.h
@@ -49,6 +49,7 @@ typedef struct app_settings_t {
     bool syskey_capture;
     bool hid_passthrough;
     int hid_passthrough_port;
+    bool hid_passthrough_autoplug;   /* auto-bridge connected game controllers on stream start + BT hotplug */
     bool hdr;   /* HDR10 (PQ) over HEVC Main10 or AV1 Main10 when host and decoder support it */
     bool force_full_color_range; /* SDR only: request full-range YUV (0-255) from host. No effect when HDR is on. */
     /**

--- a/src/app/hid_passthrough/ctm/ctm_state.c
+++ b/src/app/hid_passthrough/ctm/ctm_state.c
@@ -36,6 +36,8 @@ bool g_stop_sniff_thread_started;
 pthread_mutex_t g_bt_mac_mutex = PTHREAD_MUTEX_INITIALIZER;
 char g_bt_macs[MAX_DEVICES][64];
 int g_bt_mac_count;
+autoplug_entry_t g_autoplug[MAX_DEVICES];
+int g_autoplug_count;
 
 char g_log[LOG_LEN];
 size_t g_log_used;

--- a/src/app/hid_passthrough/ctm/ctm_state.h
+++ b/src/app/hid_passthrough/ctm/ctm_state.h
@@ -162,6 +162,22 @@ extern pthread_mutex_t g_bt_mac_mutex;
 extern char g_bt_macs[MAX_DEVICES][64];
 extern int g_bt_mac_count;
 
+/* ---- auto-plug reconcile state (ui_bridge.c) ----------------------------- */
+typedef enum {
+    AUTOPLUG_PENDING = 0,   /* recognized controller, not yet bridged: eligible */
+    AUTOPLUG_DONE,          /* bridged by us, or the user took manual control */
+    AUTOPLUG_GIVEUP         /* repeated plug failures: stop retrying until reconnect */
+} autoplug_state_t;
+
+typedef struct {
+    char key[96];
+    autoplug_state_t state;
+    int fail_count;
+} autoplug_entry_t;
+
+extern autoplug_entry_t g_autoplug[MAX_DEVICES];
+extern int g_autoplug_count;
+
 extern char g_log[LOG_LEN];
 extern size_t g_log_used;
 extern pthread_mutex_t g_log_mutex;   /* guards g_log + g_log_dirty */
@@ -235,6 +251,15 @@ void release_local_sessions_on_exit(void);
 const char *bridge_kind_for_item(const logical_device_t *item);
 bool plug_in_item(logical_device_t *item);
 bool plug_in_node(logical_device_t *item, int scan_index);   /* bridge ONE chosen hidraw */
+
+/* Auto-plug reconcile: bridge every connected, recognized controller that is not
+ * already plugged and is still auto-managed. Idempotent; cheap when nothing new. */
+void hid_pt_autoplug_reconcile(void);
+/* Mark a device key as user-/manager-owned so the reconcile leaves it alone (e.g.
+ * after a manual plug-out). Cleared when the device disconnects. */
+void autoplug_mark_done(const char *key);
+/* Forget all auto-plug bookkeeping (called when the passthrough session stops). */
+void autoplug_reset(void);
 void node_session_key(const logical_device_t *item, int scan_index, char *out, size_t out_len);
 
 /* Host app (moonlight-tv): pin the Windows CTM agent to the streaming PC IP. */

--- a/src/app/hid_passthrough/ctm/ui_bridge.c
+++ b/src/app/hid_passthrough/ctm/ui_bridge.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/wait.h>
 #include <time.h>
@@ -258,12 +259,47 @@ int send_agent_command(const char *command, char *response, size_t response_len)
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;
     addr.sin_port = htons((uint16_t)g_agent_port);
-    if (inet_aton(g_agent_host, &addr.sin_addr) == 0 ||
-        connect(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+    if (inet_aton(g_agent_host, &addr.sin_addr) == 0) {
         close(fd);
         g_agent_online = false;
         return -1;
     }
+    /* Non-blocking connect with a bounded timeout: SO_SNDTIMEO does NOT cap the
+     * TCP connect phase, so a host that silently drops SYNs (firewall) would hang
+     * the caller for tens of seconds. These commands now also run on a stream-time
+     * poll on the UI thread, so a stall must never happen. */
+    int sock_flags = fcntl(fd, F_GETFL, 0);
+    fcntl(fd, F_SETFL, sock_flags | O_NONBLOCK);
+    int crc = connect(fd, (struct sockaddr *)&addr, sizeof(addr));
+    if (crc != 0) {
+        if (errno != EINPROGRESS) {
+            close(fd);
+            g_agent_online = false;
+            return -1;
+        }
+        fd_set wfds;
+        FD_ZERO(&wfds);
+        FD_SET(fd, &wfds);
+        /* The agent is the stream host we're already connected to — a healthy LAN
+         * connect completes in a few ms. Keep this short so a host that black-holes
+         * SYNs can't stall the UI thread (these run on the auto-plug poll). */
+        struct timeval ctv;
+        ctv.tv_sec = 0;
+        ctv.tv_usec = 300000;
+        if (select(fd + 1, NULL, &wfds, NULL, &ctv) <= 0) {
+            close(fd);
+            g_agent_online = false;
+            return -1;
+        }
+        int soerr = 0;
+        socklen_t soerr_len = sizeof(soerr);
+        if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &soerr, &soerr_len) != 0 || soerr != 0) {
+            close(fd);
+            g_agent_online = false;
+            return -1;
+        }
+    }
+    fcntl(fd, F_SETFL, sock_flags);   /* restore blocking; send/recv bounded by SO_*TIMEO */
 
     char line[512];
     snprintf(line, sizeof(line), "%s\n", command);
@@ -356,7 +392,12 @@ void stop_session(const char *key)
         ctm_controller_destroy(g_sessions[index].controller);
         g_sessions[index].controller = NULL;
     }
-    if (g_sessions[index].port > 0) {
+    /* Tell the host to drop the bridge — but skip the (blocking) round-trip when
+     * the agent is already known unreachable: it would only time out, and the
+     * first failure flips g_agent_online, so a mass-disconnect against a dead host
+     * costs at most one connect timeout on the UI thread (not one per device). The
+     * host GCs orphan virtual controllers when it comes back anyway. */
+    if (g_sessions[index].port > 0 && g_agent_online) {
         char cmd[160];
         char response[256];
         snprintf(cmd, sizeof(cmd), "BRIDGE_STOP %s", g_sessions[index].busid);
@@ -537,5 +578,189 @@ bool plug_in_node(logical_device_t *item, int scan_index)
     char key[96];
     node_session_key(item, scan_index, key, sizeof(key));
     return plug_in_scan_index(item, scan_index, key);
+}
+
+/* ---- auto-plug reconcile ------------------------------------------------- */
+
+#define AUTOPLUG_MAX_FAILS 3
+/* After a failed plug attempt (a blocking agent round-trip that just stalled the
+ * UI thread), skip plug attempts for this many polls so an unreachable/slow host
+ * can't stall the main loop every tick. */
+#define AUTOPLUG_FAIL_COOLDOWN_POLLS 4
+static int g_autoplug_plug_cooldown;
+
+static autoplug_entry_t *autoplug_entry_for(const char *key, bool create)
+{
+    if (!key || !key[0]) return NULL;
+    for (int i = 0; i < g_autoplug_count; ++i) {
+        if (strcmp(g_autoplug[i].key, key) == 0) {
+            return &g_autoplug[i];
+        }
+    }
+    if (!create || g_autoplug_count >= MAX_DEVICES) return NULL;
+    autoplug_entry_t *e = &g_autoplug[g_autoplug_count++];
+    memset(e, 0, sizeof(*e));
+    snprintf(e->key, sizeof(e->key), "%s", key);
+    e->state = AUTOPLUG_PENDING;
+    return e;
+}
+
+void autoplug_mark_done(const char *key)
+{
+    autoplug_entry_t *e = autoplug_entry_for(key, true);
+    if (e) {
+        e->state = AUTOPLUG_DONE;
+        e->fail_count = 0;
+    }
+}
+
+void autoplug_reset(void)
+{
+    g_autoplug_count = 0;
+    g_autoplug_plug_cooldown = 0;
+}
+
+/* A device's "plugged" flag is persisted only in g_plugged_keys, which is NOT
+ * pruned when the device physically disappears. Without this, a controller that
+ * sleeps / disconnects and reconnects mid-stream would come back wearing a stale
+ * "plugged" flag and the reconcile would never re-bridge it. Reap any plugged key
+ * whose device is gone: tear down the now-dead local session (stop_session also
+ * BRIDGE_STOPs the host so it doesn't accumulate orphan virtual controllers) and
+ * clear the flag, so the device is auto-plugged afresh when it returns. */
+static void autoplug_reap_vanished(void)
+{
+    for (int i = 0; i < g_plugged_key_count;) {
+        bool present = false;
+        for (int j = 0; j < g_devices.count; ++j) {
+            if (strcmp(g_devices.items[j].key, g_plugged_keys[i]) == 0) {
+                present = true;
+                break;
+            }
+        }
+        if (present) {
+            ++i;
+            continue;
+        }
+        /* Absent. Copy the key first: stop_session/set_plug_key mutate g_sessions /
+         * g_plugged_keys (the latter shrinks via memmove), so do not advance i. */
+        char key[96];
+        snprintf(key, sizeof(key), "%s", g_plugged_keys[i]);
+        stop_session(key);
+        set_plug_key(key, false);
+    }
+}
+
+/* Drop bookkeeping for devices no longer present so a controller that
+ * disconnects and reconnects (e.g. a DualSense re-paired over Bluetooth) is
+ * auto-plugged afresh, and a previously "given up" device gets a clean retry. */
+static void autoplug_prune(void)
+{
+    for (int i = 0; i < g_autoplug_count;) {
+        bool present = false;
+        for (int j = 0; j < g_devices.count; ++j) {
+            if (strcmp(g_devices.items[j].key, g_autoplug[i].key) == 0) {
+                present = true;
+                break;
+            }
+        }
+        if (present) {
+            ++i;
+        } else {
+            memmove(&g_autoplug[i], &g_autoplug[i + 1],
+                    (size_t)(g_autoplug_count - i - 1) * sizeof(g_autoplug[0]));
+            g_autoplug_count--;
+        }
+    }
+}
+
+/* Defensive secondary gate for AUTO-plug ONLY (manual plug stays unrestricted):
+ * never auto-bridge an interface that identifies itself as a keyboard / keypad /
+ * mouse / pointer / consumer-control, even if it somehow carried a controller
+ * VID/PID. A DualSense's gamepad interface reports Generic-Desktop/Gamepad, so
+ * this never blocks it; an undetermined usage (0) falls through to the VID/PID
+ * gate. This is what keeps e.g. a Bluetooth keyboard or media remote from ever
+ * being passed to the host. */
+static bool usage_is_input_peripheral(uint16_t up, uint16_t us)
+{
+    if (up == 0x0c) return true;            /* Consumer Control (media keys/remote) */
+    if (up == 0x01) {                       /* Generic Desktop */
+        return us == 0x01 ||                /*   Pointer   */
+               us == 0x02 ||                /*   Mouse     */
+               us == 0x06 ||                /*   Keyboard  */
+               us == 0x07;                  /*   Keypad    */
+    }
+    return false;
+}
+
+static bool autoplug_node_is_peripheral(const logical_device_t *item)
+{
+    int idx = first_scan_index_for_item(item);
+    if (idx < 0 || idx >= g_scan.count) {
+        return false;
+    }
+    return usage_is_input_peripheral(g_scan.devices[idx].usage_page,
+                                     g_scan.devices[idx].usage);
+}
+
+void hid_pt_autoplug_reconcile(void)
+{
+    autoplug_reap_vanished();   /* drop stale plugged state for devices that left */
+    autoplug_prune();           /* drop bookkeeping for devices that left */
+
+    /* Backing off after a recent plug failure: don't issue any (blocking) agent
+     * round-trips this tick, but still record manually/already-plugged devices so a
+     * deliberate plug-out keeps being respected. */
+    if (g_autoplug_plug_cooldown > 0) {
+        g_autoplug_plug_cooldown--;
+        for (int i = 0; i < g_devices.count; ++i) {
+            if (g_devices.items[i].plugged) {
+                autoplug_mark_done(g_devices.items[i].key);
+            }
+        }
+        return;
+    }
+
+    for (int i = 0; i < g_devices.count; ++i) {
+        logical_device_t *item = &g_devices.items[i];
+        if (item->plugged) {
+            /* Already bridged (by us or manually): remember it so a later manual
+             * plug-out is respected instead of being re-plugged on the next poll. */
+            autoplug_mark_done(item->key);
+            continue;
+        }
+        const char *kind = bridge_kind_for_item(item);
+        if (strcmp(kind, "hid") == 0) {
+            continue;   /* only known controllers (ds5/ds4/xbox/puck), never generic HID */
+        }
+        /* The puck is a composite device whose first interface may be keyboard/
+         * mouse; its dedicated handling picks the gamepad interface, so don't apply
+         * the peripheral guard to it. For the simple pads, refuse anything that
+         * presents as a keyboard/mouse/consumer-control interface. */
+        if (strcmp(kind, "puck") != 0 && autoplug_node_is_peripheral(item)) {
+            continue;
+        }
+        autoplug_entry_t *e = autoplug_entry_for(item->key, true);
+        if (!e || e->state != AUTOPLUG_PENDING) {
+            continue;   /* DONE (user-managed) or GIVEUP */
+        }
+        if (plug_in_item(item)) {
+            item->plugged = true;
+            set_plug_key(item->key, true);
+            e->state = AUTOPLUG_DONE;
+            e->fail_count = 0;
+            log_append("auto-plugged %s (%s)", item->name, kind);
+            /* success is cheap; keep going so a second controller plugs the same tick */
+        } else {
+            if (++e->fail_count >= AUTOPLUG_MAX_FAILS) {
+                e->state = AUTOPLUG_GIVEUP;
+                log_append("auto-plug: giving up on %s after %d attempts", item->name, e->fail_count);
+            }
+            /* A failure means a blocking agent round-trip just stalled the UI thread.
+             * Stop after the first failure this tick and back off, so an unreachable
+             * or slow host can't freeze the main loop on every poll. */
+            g_autoplug_plug_cooldown = AUTOPLUG_FAIL_COOLDOWN_POLLS;
+            break;
+        }
+    }
 }
 

--- a/src/app/hid_passthrough/hid_passthrough_manager.c
+++ b/src/app/hid_passthrough/hid_passthrough_manager.c
@@ -29,13 +29,15 @@ void hid_passthrough_manager_deinit(hid_passthrough_manager_t *manager) {
     hid_passthrough_manager_stop(manager);
 }
 
-int hid_passthrough_manager_start(hid_passthrough_manager_t *manager, const char *host, int port) {
+int hid_passthrough_manager_start(hid_passthrough_manager_t *manager, const char *host, int port,
+                                  bool autoplug) {
     if (!manager || !host || !host[0]) {
         return -1;
     }
     strncpy(manager->host, host, sizeof(manager->host) - 1);
     manager->host[sizeof(manager->host) - 1] = '\0';
     manager->port = port > 0 ? port : HID_PT_DEFAULT_PORT;
+    manager->autoplug = autoplug;
 
     ctm_bridge_set_agent_host(manager->host, manager->port);
     g_running = true;
@@ -59,6 +61,7 @@ void hid_passthrough_manager_stop(hid_passthrough_manager_t *manager) {
     release_local_sessions_on_exit();
     g_plugged_key_count = 0;
     g_expanded_key_count = 0;
+    autoplug_reset();
     hid_pt_sync_plugged_state();
     manager->running = false;
 }
@@ -160,6 +163,16 @@ void hid_passthrough_manager_rescan(hid_passthrough_manager_t *manager) {
     }
 
     hid_pt_sync_plugged_state();
+}
+
+void hid_passthrough_manager_poll(hid_passthrough_manager_t *manager) {
+    if (!manager || !manager->running) {
+        return;
+    }
+    hid_passthrough_manager_rescan(manager);
+    if (manager->autoplug) {
+        hid_pt_autoplug_reconcile();
+    }
 }
 
 #endif

--- a/src/app/hid_passthrough/hid_passthrough_manager.h
+++ b/src/app/hid_passthrough/hid_passthrough_manager.h
@@ -11,6 +11,7 @@
 
 struct hid_passthrough_manager {
     bool running;
+    bool autoplug;
     char host[128];
     int port;
 };
@@ -32,11 +33,18 @@ void hid_passthrough_manager_init(hid_passthrough_manager_t *manager);
 
 void hid_passthrough_manager_deinit(hid_passthrough_manager_t *manager);
 
-int hid_passthrough_manager_start(hid_passthrough_manager_t *manager, const char *host, int port);
+int hid_passthrough_manager_start(hid_passthrough_manager_t *manager, const char *host, int port,
+                                  bool autoplug);
 
 void hid_passthrough_manager_stop(hid_passthrough_manager_t *manager);
 
 bool hid_passthrough_manager_active(const hid_passthrough_manager_t *manager);
+
+/* Rescan attached HID devices and, when autoplug is enabled, bridge any connected
+ * game controller (DS5/DS4/Xbox/puck) that is not already plugged. Idempotent and
+ * safe to call on a cadence to pick up controllers connected mid-stream (e.g. a
+ * DualSense paired over Bluetooth while a game is running). LVGL-thread only. */
+void hid_passthrough_manager_poll(hid_passthrough_manager_t *manager);
 
 int hid_passthrough_manager_device_count(hid_passthrough_manager_t *manager);
 
@@ -74,10 +82,12 @@ static inline void hid_passthrough_manager_deinit(hid_passthrough_manager_t *man
     (void) manager;
 }
 
-static inline int hid_passthrough_manager_start(hid_passthrough_manager_t *manager, const char *host, int port) {
+static inline int hid_passthrough_manager_start(hid_passthrough_manager_t *manager, const char *host, int port,
+                                                bool autoplug) {
     (void) manager;
     (void) host;
     (void) port;
+    (void) autoplug;
     return -1;
 }
 
@@ -88,6 +98,10 @@ static inline void hid_passthrough_manager_stop(hid_passthrough_manager_t *manag
 static inline bool hid_passthrough_manager_active(const hid_passthrough_manager_t *manager) {
     (void) manager;
     return false;
+}
+
+static inline void hid_passthrough_manager_poll(hid_passthrough_manager_t *manager) {
+    (void) manager;
 }
 
 #endif

--- a/src/app/stream/session.c
+++ b/src/app/stream/session.c
@@ -159,7 +159,8 @@ bool session_start_input(session_t *session) {
 #endif
     if (session->config.hid_passthrough) {
         hid_passthrough_manager_start(&session->hid_pt, session->server->serverInfo.address,
-                                      session->config.hid_passthrough_port);
+                                      session->config.hid_passthrough_port,
+                                      session->config.hid_passthrough_autoplug);
     }
     session_input_started(&session->input);
     return true;
@@ -190,7 +191,8 @@ void session_ensure_hid_passthrough(session_t *session) {
         return;
     }
     hid_passthrough_manager_start(&session->hid_pt, session->server->serverInfo.address,
-                                  session->config.hid_passthrough_port);
+                                  session->config.hid_passthrough_port,
+                                  session->config.hid_passthrough_autoplug);
 }
 
 void session_toggle_vmouse(session_t *session) {
@@ -306,6 +308,7 @@ void session_config_init(app_t *app, session_config_t *config, const SERVER_DATA
     }
     config->hid_passthrough = app_config->hid_passthrough;
     config->hid_passthrough_port = app_config->hid_passthrough_port > 0 ? app_config->hid_passthrough_port : 48054;
+    config->hid_passthrough_autoplug = app_config->hid_passthrough_autoplug;
 
     SS4S_VideoCapabilities video_cap = app->ss4s.video_cap;
     SS4S_AudioCapabilities audio_cap = app->ss4s.audio_cap;

--- a/src/app/stream/session.h
+++ b/src/app/stream/session.h
@@ -65,6 +65,7 @@ typedef struct session_config_t {
     uint8_t stick_deadzone;
     bool hid_passthrough;
     int hid_passthrough_port;
+    bool hid_passthrough_autoplug;
 } session_config_t;
 
 extern int streaming_errno;

--- a/src/app/ui/root.c
+++ b/src/app/ui/root.c
@@ -9,6 +9,7 @@
 
 #include "stream/session.h"
 #include "stream/input/session_input.h"
+#include "hid_passthrough/hid_passthrough_manager.h"
 
 #include "streaming/streaming.controller.h"
 #include "launcher/launcher.controller.h"
@@ -49,6 +50,43 @@ SDL_Window *app_ui_create_window(app_ui_t *ui);
 static void session_error();
 
 static void session_error_dialog_cb(lv_event_t *event);
+
+#if defined(TARGET_WEBOS)
+/* Drives HID-passthrough auto-plug for the whole stream: rescans attached
+ * devices on a cadence and bridges any recognized controller that is not yet
+ * plugged. This is what makes a DualSense connected at stream start — or paired
+ * over Bluetooth mid-game — get passed through without opening the HID overlay.
+ * Lives on the LVGL/main thread (lv_timer), the same thread as the panel and all
+ * plug operations, so the device model needs no locking. */
+#define HID_AUTOPLUG_POLL_MS 1000
+static lv_timer_t *hid_autoplug_timer = NULL;
+
+static void hid_autoplug_timer_cb(lv_timer_t *timer) {
+    app_t *app = timer->user_data;
+    if (app == NULL || app->session == NULL) {
+        return;
+    }
+    hid_passthrough_manager_t *mgr = session_get_hid_passthrough(app->session);
+    if (mgr != NULL) {
+        hid_passthrough_manager_poll(mgr);
+    }
+}
+
+static void hid_autoplug_timer_stop(void) {
+    if (hid_autoplug_timer != NULL) {
+        lv_timer_del(hid_autoplug_timer);
+        hid_autoplug_timer = NULL;
+    }
+}
+
+static void hid_autoplug_timer_start(app_t *app) {
+    hid_autoplug_timer_stop();
+    hid_passthrough_manager_t *mgr = session_get_hid_passthrough(app->session);
+    if (mgr != NULL && hid_passthrough_manager_active(mgr)) {
+        hid_autoplug_timer = lv_timer_create(hid_autoplug_timer_cb, HID_AUTOPLUG_POLL_MS, app);
+    }
+}
+#endif
 
 void app_ui_init(app_ui_t *ui, app_t *app) {
     ui->app = app;
@@ -191,12 +229,20 @@ bool ui_dispatch_userevent(app_t *app, int which, void *data1, void *data2) {
                 if (session_start_input(app->session)) {
                     app_set_mouse_grab(&app->input, true);
                 }
+#if defined(TARGET_WEBOS)
+                /* Begin auto-plugging connected/hotplugged controllers for the
+                 * duration of this stream (no-op unless hid_passthrough is on). */
+                hid_autoplug_timer_start(app);
+#endif
                 app_set_keep_awake(app, true);
                 streaming_enter_fullscreen(app->session);
                 last_pts = 0;
                 return true;
             }
             case USER_STREAM_CLOSE: {
+#if defined(TARGET_WEBOS)
+                hid_autoplug_timer_stop();
+#endif
                 if (app->ss4s.video_cap.transform & SS4S_VIDEO_CAP_TRANSFORM_UI_EXCLUSIVE) {
                     SDL_ShowCursor(SDL_TRUE);
                 } else {
@@ -217,6 +263,11 @@ bool ui_dispatch_userevent(app_t *app, int which, void *data1, void *data2) {
                 return true;
             }
             case USER_STREAM_FINISHED: {
+#if defined(TARGET_WEBOS)
+                /* Terminal event for every teardown (posted just before the session
+                 * is destroyed) — make sure the poll timer never outlives it. */
+                hid_autoplug_timer_stop();
+#endif
                 if (streaming_errno != 0) {
                     session_error();
                     break;

--- a/src/app/ui/streaming/hid_passthrough_panel.c
+++ b/src/app/ui/streaming/hid_passthrough_panel.c
@@ -95,6 +95,10 @@ static void plug_button_cb(lv_event_t *event) {
 
     item->plugged = requested_state;
     set_plug_key(item->key, item->plugged);
+    /* The user took manual control of this device: stop auto-managing it (so a
+     * deliberate plug-out is not re-plugged by the reconcile poll) until it
+     * physically reconnects. */
+    autoplug_mark_done(item->key);
     panel->selected_index = index;
     snprintf(panel->selected_key, sizeof(panel->selected_key), "%s", item->key);
 


### PR DESCRIPTION
Adds an optional auto-plug mode (hid_passthrough_autoplug, default on) that
bridges any recognized game controller — DS5/DS4/Xbox/8BitDo-puck — to the host
as soon as a stream starts and whenever one is hot-plugged, instead of requiring
a manual bridge action per controller.

- a reconcile pass on an lv_timer cadence on the LVGL/main thread scans
  connected devices and bridges those not yet passed through; generic/unknown
  HID is never auto-bridged (allowlist by interface)
- driven only through the existing hid_passthrough_manager API; no dependency on
  any controller transport internals
- settings-backed (app_settings) + wired through session config and the
  passthrough panel

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

