### PR TITLE
DS5: feedback-latency pace clamp, per-burst input coalescing, battery overlay

### DIFF
--- a/src/app/hid_passthrough/ctm/controllers/controller_common.c
+++ b/src/app/hid_passthrough/ctm/controllers/controller_common.c
@@ -148,6 +148,7 @@ struct ctm_controller {
     volatile int st_transport_enet;
     volatile unsigned long st_reports_in;
     volatile unsigned long st_reports_out;
+    volatile unsigned long st_coalesced;   /* input reports dropped by per-burst coalescing */
     char st_last_event[96];
 
     uint8_t *enum_payload;           /* composite: forwarded enumeration (CTMB_MSG_ENUM) */
@@ -1334,10 +1335,23 @@ static void *composite_reader_main(void *arg)
     return NULL;
 }
 
+/* Per-burst input coalescing. The WiFi+BT combo chip starves BT scheduling under
+ * heavy stream RX, so the DS5 buffers reports across a ~16-28ms stall then flushes
+ * them back-to-back. Forwarding every stale report FIFO over usbip backlogs the
+ * game's HID input queue and adds felt latency; SDL/Moonlight only ever consumed
+ * the latest gamepad state, which is why the SDL path felt smoother. Match that:
+ * within ONE readable burst keep only the most recent report per report-id, then
+ * forward. In steady state a poll yields a single report, so this is a no-op. */
+#define CTM_COAL_MAX_IDS 6
 static void *input_thread_main(void *arg)
 {
     ctm_controller_t *c = (ctm_controller_t *)arg;
     ctl_set_rt_prio(c, "ctm-input", 12);
+    /* Allocated once (MAX_REPORT is 4096); per-thread so concurrent controllers
+     * don't share. */
+    static __thread uint8_t coal_buf[CTM_COAL_MAX_IDS][MAX_REPORT];
+    size_t  coal_len[CTM_COAL_MAX_IDS];
+    uint8_t coal_id[CTM_COAL_MAX_IDS];
     while (!c->stop) {
         struct pollfd pfds[2];
         pfds[0].fd = c->hid_fd; pfds[0].events = POLLIN; pfds[0].revents = 0;
@@ -1348,20 +1362,34 @@ static void *input_thread_main(void *arg)
         if (pfds[1].revents & POLLIN) break;
         if (pfds[0].revents & (POLLERR | POLLHUP | POLLNVAL)) break;
         if (!(pfds[0].revents & POLLIN)) continue;
+        int coal_n = 0, drained = 0;
         for (;;) {
             uint8_t buf[MAX_REPORT];
             ssize_t n = read(c->hid_fd, buf, sizeof(buf));
-            if (n > 0) {
-                if (c_send(c, CTMB_MSG_INPUT_REPORT, CTMB_FLAG_OK, c->primary_in_ep, buf, (size_t)n) != 0) {
-                    c->stop = 1;
-                    break;
-                }
-                c->st_reports_in++;
-                continue;
+            if (n <= 0) {
+                if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) break;
+                break;
             }
-            if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) break;
-            break;
+            uint8_t id = buf[0];
+            int slot = -1;
+            for (int i = 0; i < coal_n; ++i) if (coal_id[i] == id) { slot = i; break; }
+            if (slot < 0) {
+                slot = (coal_n < CTM_COAL_MAX_IDS) ? coal_n++ : (CTM_COAL_MAX_IDS - 1);
+                coal_id[slot] = id;
+            }
+            memcpy(coal_buf[slot], buf, (size_t)n);
+            coal_len[slot] = (size_t)n;
+            drained++;
         }
+        for (int i = 0; i < coal_n && !c->stop; ++i) {
+            if (c_send(c, CTMB_MSG_INPUT_REPORT, CTMB_FLAG_OK, c->primary_in_ep,
+                       coal_buf[i], coal_len[i]) != 0) {
+                c->stop = 1;
+                break;
+            }
+            c->st_reports_in++;
+        }
+        if (drained > coal_n) c->st_coalesced += (unsigned long)(drained - coal_n);
     }
     return NULL;
 }
@@ -1602,10 +1630,10 @@ static void run_session(ctm_controller_t *c, const ctmb_device_caps_t *caps,
                 if (c->acl_tx) {
                     ds5_acl_tx_stats(c->acl_tx, &inj, &drp, &rdy);
                 }
-                ctl_log(c, "PLC/60s: audio_omit=%lu conceal=%lu capdrop=%lu | acl_ready=%d inj=%ld drop=%ld | hid ok=%lu eagain=%lu recov=%lu drop=%lu | dedup31=%lu",
+                ctl_log(c, "PLC/60s: audio_omit=%lu conceal=%lu capdrop=%lu | acl_ready=%d inj=%ld drop=%ld | hid ok=%lu eagain=%lu recov=%lu drop=%lu | dedup31=%lu | in=%lu coal=%lu",
                         c->st_audio_omit, c->st_audio_conceal, c->st_audio_capdrop, rdy, inj, drp,
                         c->st_hid_ok, c->st_hid_eagain, c->st_hid_recovered, c->st_hid_dropped,
-                        c->st_dedup_skipped);
+                        c->st_dedup_skipped, c->st_reports_in, c->st_coalesced);
                 c->st_audio_omit = c->st_audio_conceal = c->st_audio_capdrop = 0;
                 c->st_hid_ok = c->st_hid_eagain = c->st_hid_recovered = c->st_hid_dropped = 0;
                 c->st_dedup_skipped = 0;

--- a/src/app/hid_passthrough/ctm/controllers/controller_common.c
+++ b/src/app/hid_passthrough/ctm/controllers/controller_common.c
@@ -1577,7 +1577,21 @@ static void run_session(ctm_controller_t *c, const ctmb_device_caps_t *caps,
 
     int link_alive = 1;
     while (!c->stop && link_alive) {
-        drain_paced(c, paced_q, &paced_head, &paced_count, &next_paced_us, host_cfg.bt_pace_us);
+        /* The ~10.6ms host pace (~94/s) was sized for the BT one-outstanding wall
+         * on the hidraw write path. The raw-ACL injector bypasses that wall, but at
+         * ~94/s the pace barely lags the ~100/s DS5 audio source, so the paced queue
+         * parks near-full (up to PACED_QUEUE_CAP*pace ~= 340ms of feedback latency).
+         * While the forwarder is actively injecting, tighten the pace to <=8ms so the
+         * queue drains with margin and stays shallow; the hidraw fallback keeps the
+         * conservative host pace. */
+        uint32_t eff_pace_us = host_cfg.bt_pace_us;
+        if (c->acl_tx) {
+            long ij_ = 0, dp_ = 0;
+            int rdy_ = 0;
+            ds5_acl_tx_stats(c->acl_tx, &ij_, &dp_, &rdy_);
+            if (rdy_ && eff_pace_us > 8000) eff_pace_us = 8000;
+        }
+        drain_paced(c, paced_q, &paced_head, &paced_count, &next_paced_us, eff_pace_us);
         if (c->plc_enabled) {
             uint64_t pnow = now_us();
             if (c->plc_log_next_us == 0) {

--- a/src/app/ui/streaming/streaming.controller.c
+++ b/src/app/ui/streaming/streaming.controller.c
@@ -20,6 +20,13 @@
 #include <stdio.h>
 #include <string.h>
 
+#if defined(TARGET_WEBOS)
+#include <fcntl.h>
+#include <unistd.h>
+#include <poll.h>
+#include "hid_passthrough/hid_passthrough_manager.h"
+#endif
+
 static void exit_streaming(lv_event_t *event);
 
 static void suspend_streaming(lv_event_t *event);
@@ -217,6 +224,148 @@ bool streaming_stats_shown() {
     return overlay_showing || overlay_pinned;
 }
 
+#if defined(TARGET_WEBOS)
+/* Sony DualSense family — the only controllers whose battery byte lives at the
+ * fixed offset decoded below. DS4/Xbox/puck use different layouts, so we skip them. */
+#define DS_VENDOR_SONY  0x054c
+#define DS_PRODUCT_DS5  0x0ce6
+#define DS_PRODUCT_EDGE 0x0df2
+
+/* The DualSense `status` byte sits at offset 52 of the common input-report struct.
+ * The report is prefixed by the report id plus, over Bluetooth, a 1-byte seq tag:
+ * +2 for BT report 0x31, +1 for USB report 0x01. Returns capacity 0..100 (and the
+ * charging nibble), or -1 when the report id/length is not a full DualSense report. */
+static int ds5_parse_battery(const uint8_t *buf, int len, int *charging) {
+    int off;
+    if (buf[0] == 0x31) {
+        off = 2 + 52; /* Bluetooth full report */
+    } else if (buf[0] == 0x01) {
+        off = 1 + 52; /* USB full report */
+    } else {
+        return -1;
+    }
+    if (len <= off) {
+        return -1;
+    }
+    uint8_t status = buf[off];
+    int raw = status & 0x0f;        /* 0..10 capacity, or an error code (>10) */
+    int chg = (status >> 4) & 0x0f; /* 0 discharging, 1 charging, 2 full */
+    if (charging) {
+        *charging = chg;
+    }
+    if (chg == 0x02) {
+        return 100; /* fully charged */
+    }
+    if (raw > 10) {
+        return -1; /* temperature/voltage error code, not a real level */
+    }
+    int pct = raw * 10 + 5;
+    return pct > 100 ? 100 : pct;
+}
+
+/* Read one input report off a bridged DualSense hidraw node and decode its battery.
+ * The kernel fans each hidraw report out to every open fd, so this read does NOT
+ * steal frames from the usbip passthrough that also holds the node open. */
+static int ds5_read_battery_node(const char *node, int *charging) {
+    int fd = open(node, O_RDONLY | O_NONBLOCK);
+    if (fd < 0) {
+        return -1;
+    }
+    int result = -1;
+    /* DualSense streams ~250 reports/s; poll briefly for a fresh one (~100ms cap). */
+    for (int tries = 0; tries < 8 && result < 0; tries++) {
+        struct pollfd p = {fd, POLLIN, 0};
+        if (poll(&p, 1, 12) <= 0) {
+            continue;
+        }
+        uint8_t buf[96];
+        int n = (int) read(fd, buf, sizeof(buf));
+        if (n <= 0) {
+            continue;
+        }
+        result = ds5_parse_battery(buf, n, charging);
+    }
+    close(fd);
+    return result;
+}
+
+/* Summarize the battery of every bridged DualSense into out, e.g.
+ * "75%  ·  40% (charging)" — one entry per controller in device-index order.
+ * Returns the number of controllers whose battery was decoded (0 = none). */
+static int ds5_bridged_battery_summary(streaming_controller_t *controller, char *out, size_t outlen) {
+    if (outlen) {
+        out[0] = '\0';
+    }
+    if (!controller->global || !controller->global->session) {
+        return 0;
+    }
+    hid_passthrough_manager_t *mgr = session_get_hid_passthrough(controller->global->session);
+    if (!mgr) {
+        return 0;
+    }
+    int count = hid_passthrough_manager_device_count(mgr);
+    int found = 0;
+    size_t pos = 0;
+    for (int i = 0; i < count; i++) {
+        hid_pt_device_info_t info;
+        if (hid_passthrough_manager_get_device(mgr, i, &info) != 0) {
+            continue;
+        }
+        if (!info.plugged || info.vendor_id != DS_VENDOR_SONY) {
+            continue;
+        }
+        if (info.product_id != DS_PRODUCT_DS5 && info.product_id != DS_PRODUCT_EDGE) {
+            continue;
+        }
+        if (!info.path[0]) {
+            continue;
+        }
+        int chg = 0;
+        int pct = ds5_read_battery_node(info.path, &chg);
+        if (pct < 0) {
+            continue;
+        }
+        const char *suffix = (chg == 0x01) ? " (charging)"
+                           : (chg == 0x02 || pct >= 100) ? " (full)" : "";
+        int w = snprintf(out + pos, outlen - pos, "%s%d%%%s",
+                         found ? "  \xc2\xb7  " : "", pct, suffix);
+        if (w > 0 && (size_t) w < outlen - pos) {
+            pos += (size_t) w;
+        }
+        found++;
+    }
+    return found;
+}
+#endif
+
+/* Refresh the "Controller battery" stat row. The hidraw reads are throttled to once
+ * per 10s (battery changes slowly) so reopening the nodes never janks the overlay.
+ * Shows every bridged DualSense, e.g. "75%  ·  40% (charging)". */
+static void streaming_refresh_battery(streaming_controller_t *controller) {
+    if (!controller->stats_items.battery) {
+        return;
+    }
+#if defined(TARGET_WEBOS)
+    static uint32_t last_ms = 0;
+    static int initialized = 0;
+    static char text[96];
+    uint32_t now = SDL_GetTicks();
+    if (!initialized || (now - last_ms) >= 10000) {
+        char summary[96];
+        if (ds5_bridged_battery_summary(controller, summary, sizeof summary) <= 0) {
+            snprintf(text, sizeof text, "no controller bridged");
+        } else {
+            snprintf(text, sizeof text, "%s", summary);
+        }
+        last_ms = now;
+        initialized = 1;
+    }
+    lv_label_set_text(controller->stats_items.battery, text);
+#else
+    lv_label_set_text(controller->stats_items.battery, "-");
+#endif
+}
+
 bool streaming_refresh_stats() {
     streaming_controller_t *controller = current_controller;
     if (!controller) { return false; }
@@ -334,6 +483,7 @@ bool streaming_refresh_stats() {
         lv_label_set_text_fmt(controller->stats_items.host_latency, "-");
         lv_label_set_text_fmt(controller->stats_items.vdec_latency, "-");
     }
+    streaming_refresh_battery(controller);
     return true;
 }
 

--- a/src/app/ui/streaming/streaming.controller.h
+++ b/src/app/ui/streaming/streaming.controller.h
@@ -34,6 +34,7 @@ typedef struct {
         lv_obj_t *bitrate;
         lv_obj_t *host_latency;
         lv_obj_t *vdec_latency;
+        lv_obj_t *battery;
     } stats_items;
     lv_obj_t *stats_compact_label;  /* Single-line stats when show_stats_compact */
     lv_obj_t *stats_quality_indicator;  /* Colored dot: green/yellow/red by latency */

--- a/src/app/ui/streaming/streaming.view.c
+++ b/src/app/ui/streaming/streaming.view.c
@@ -191,6 +191,7 @@ lv_obj_t *streaming_scene_create(lv_fragment_t *self, lv_obj_t *parent) {
         controller->stats_items.bitrate = NULL;
         controller->stats_items.host_latency = NULL;
         controller->stats_items.vdec_latency = NULL;
+        controller->stats_items.battery = NULL;
     } else {
         lv_obj_set_size(stats, LV_DPX(384), LV_SIZE_CONTENT);
         lv_obj_set_flex_flow(stats, LV_FLEX_FLOW_ROW_WRAP);
@@ -208,6 +209,7 @@ lv_obj_t *streaming_scene_create(lv_fragment_t *self, lv_obj_t *parent) {
         controller->stats_items.bitrate = stat_label(stats, "Bitrate");
         controller->stats_items.host_latency = stat_label(stats, "Host processing latency");
         controller->stats_items.vdec_latency = stat_label(stats, "Decoder latency");
+        controller->stats_items.battery = stat_label(stats, "Controller battery");
     }
 
 


### PR DESCRIPTION
Three DS5 output/UX improvements we run in production (LG G4, DualSense over BT) on top of the raw-ACL forwarder merged from PR #18 (`67e7eae5`). Extracted from our webOS build and **re-implemented on top of current `main`** (not cherry-picked, to avoid the ctm→ds5 rename churn). webOS-ARM cross-compile is clean (compile + link).

**1. `clamp DS5 BT pace to <=8ms while the raw-ACL forwarder is ready`**
When `ds5_acl_tx` reports ready, clamp the paced-drain interval (`host_cfg.bt_pace_us`) to ≤8000µs. The conservative host pace (~10.6ms) parks the paced feedback queue near-full, adding up to ~340ms worst-case output-feedback latency (rumble/trigger/LED round-trip). The raw-ACL path sustains a tighter grid, so draining at ≤8ms keeps the queue shallow. Falls back to the host pace when the forwarder isn't ready (hidraw path).

**2. `per-burst input coalescing to mask WiFi+BT co-existence stalls`**
The WiFi+BT combo chip periodically starves BT scheduling; a stall lets multiple input reports of the same report-id pile up, and forwarding all of them adds latency for no benefit. Coalesce each drain burst keeping the latest report per id (≤6 ids) before forwarding. Adds an `st_coalesced` counter to the PLC/60s telemetry line.

**3. `show bridged DualSense battery in the performance overlay`**
Adds a "Controller battery" row to the streaming stats overlay (webOS only): reads the bridged DualSense hidraw node(s), decodes the DS5 status byte, and summarizes capacity. Purely additive; piggybacks the existing stats refresh tick (no new timer). Does not touch the HID-panel bus flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
