### PR TITLE
fix(hid-autoplug): persist per-device auto-plug prefs across a full settings save

### DIFF
--- a/src/app/app_settings.c
+++ b/src/app/app_settings.c
@@ -231,6 +231,14 @@ bool settings_save(app_settings_t *config) {
         ini_write_int(fp, "height", config->window_state.h);
     }
 
+#if defined(TARGET_WEBOS)
+    /* settings_save() truncates and rewrites the whole ini from known fields, so
+     * without this the per-device HID auto-plug prefs written by
+     * hid_pt_prefs_flush() are silently dropped on the next full save (e.g. app
+     * exit) — the DualSense would then fail to auto-bridge on the next launch. */
+    hid_pt_prefs_write_section(fp);
+#endif
+
     return fclose(fp) == 0;
 }
 

--- a/src/app/hid_passthrough/hid_pt_device_prefs.c
+++ b/src/app/hid_passthrough/hid_pt_device_prefs.c
@@ -183,6 +183,17 @@ int hid_pt_prefs_ini_handler(const char *section, const char *name, const char *
     return 1;
 }
 
+void hid_pt_prefs_write_section(FILE *fp)
+{
+    if (!fp || g_hid_pt_pref_count <= 0) {
+        return;
+    }
+    ini_write_section(fp, "hid_pt_devices");
+    for (int i = 0; i < g_hid_pt_pref_count; ++i) {
+        ini_write_bool(fp, g_hid_pt_prefs[i].id, g_hid_pt_prefs[i].auto_plugin);
+    }
+}
+
 void hid_pt_prefs_flush(void)
 {
     if (!app_configuration || !app_configuration->ini_path) {
@@ -248,10 +259,7 @@ void hid_pt_prefs_flush(void)
     }
     free(lines);
 
-    ini_write_section(fp, "hid_pt_devices");
-    for (int i = 0; i < g_hid_pt_pref_count; ++i) {
-        ini_write_bool(fp, g_hid_pt_prefs[i].id, g_hid_pt_prefs[i].auto_plugin);
-    }
+    hid_pt_prefs_write_section(fp);
     fclose(fp);
 }
 

--- a/src/app/hid_passthrough/hid_pt_device_prefs.h
+++ b/src/app/hid_passthrough/hid_pt_device_prefs.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdio.h>
 
 #if defined(TARGET_WEBOS)
 
@@ -19,6 +20,11 @@ void hid_pt_stable_id_for_gamepad(const app_gamepad_state_t *gamepad, char *out,
 bool hid_pt_prefs_get_auto_plugin(const char *stable_id);
 void hid_pt_prefs_set_auto_plugin(const char *stable_id, bool enabled);
 void hid_pt_prefs_flush(void);
+
+/* Emit the [hid_pt_devices] section into an already-open ini writer. Used by
+ * settings_save() so a full-config rewrite preserves the per-device prefs
+ * instead of truncating them. */
+void hid_pt_prefs_write_section(FILE *fp);
 
 bool hid_pt_prefs_auto_plugin_for_logical(const logical_device_t *item);
 bool hid_pt_prefs_auto_plugin_for_gamepad(const app_gamepad_state_t *gamepad);


### PR DESCRIPTION
## Problem

The per-device HID auto-plug preference (the "Auto-Plugin" toggle in the in-stream device overlay) does not survive an app restart. After enabling it for a controller, quitting and relaunching, the controller is no longer auto-bridged — even though the toggle looked persisted.

## Root cause

`settings_save()` opens the ini with `fopen(ini_path, "w")`, truncating the whole file and rewriting only the known config fields. It never emits the `[hid_pt_devices]` section, and does not preserve unknown sections. Meanwhile `hid_pt_prefs_flush()` writes that section via a read-modify-write.

So the sequence is:
1. Toggle auto-plug → `hid_pt_prefs_flush()` writes `[hid_pt_devices]`. ✅
2. Any later full save (app exit, or changing any other setting) → `settings_save()` truncates and rewrites **without** the section → the per-device pref is silently dropped. ❌
3. Next launch → no `[hid_pt_devices]` → the device is never auto-bridged.

(Verified on-device: after a toggle, `moonlight.ini` had `hid_passthrough_autoplug = true` but no `[hid_pt_devices]` section.)

## Fix

Expose `hid_pt_prefs_write_section(FILE *)` (refactored out of `hid_pt_prefs_flush()`, so there is a single section writer) and call it at the end of `settings_save()` on webOS, before `fclose`. A full rewrite now preserves the per-device prefs.

## Testing

Built for webOS (arm) and validated on an LG G4: enable auto-plug for a DualSense, quit/relaunch → the pad is auto-bridged in the new session; the `[hid_pt_devices]` section persists across other settings changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjSNtU6rUU379KdGgZR5yF
