### PR TITLE
Improve UI navigation, game grid paging, and Docker LL build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/mariotaku/ss4s.git
 [submodule "third_party/commons"]
 	path = third_party/commons
-	url = https://github.com/mariotaku/commons-c.git
+	url = https://github.com/GuiDev1994/commons-c.git

--- a/scripts/webos/build_with_docker.ps1
+++ b/scripts/webos/build_with_docker.ps1
@@ -1,5 +1,6 @@
 # Build Aurora for LG webOS via Docker
 # Works on Windows without WSL Ubuntu - uses an Ubuntu container
+# Low-latency variant: scripts/webos/build_with_docker_ll.ps1
 
 $ErrorActionPreference = "Stop"
 $ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/scripts/webos/build_with_docker_ll.ps1
+++ b/scripts/webos/build_with_docker_ll.ps1
@@ -1,0 +1,49 @@
+# Build Aurora for LG webOS via Docker (NDL low-latency variant)
+# Applies WEBOS_NDL_LOW_LATENCY=1 — PTS=0 in ndl-webos5 for lower display latency.
+# Output: dist/*_ll.ipk (test on your TV before daily use; A/V drift possible on some models)
+
+$ErrorActionPreference = "Stop"
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+
+Write-Host "=== Aurora - Build for LG webOS (Docker, NDL low-latency) ===" -ForegroundColor Cyan
+Write-Host ""
+
+$dockerOk = $false
+$ErrorActionPreferenceBak = $ErrorActionPreference
+$ErrorActionPreference = "SilentlyContinue"
+& docker ps *>$null
+$dockerOk = ($LASTEXITCODE -eq 0)
+$ErrorActionPreference = $ErrorActionPreferenceBak
+if (-not $dockerOk) {
+    Write-Host "ERROR: Docker is not running or is not installed." -ForegroundColor Red
+    Write-Host "  - Install Docker Desktop: https://www.docker.com/products/docker-desktop" -ForegroundColor Yellow
+    Write-Host "  - Or use: WEBOS_NDL_LOW_LATENCY=1 ./scripts/webos/build_for_lg.sh (inside WSL/Linux)" -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "Using Docker (NDL low-latency patches enabled)..." -ForegroundColor Green
+Write-Host "  WEBOS_NDL_LOW_LATENCY=1" -ForegroundColor DarkGray
+Write-Host ""
+
+$ScriptPath = Join-Path $PSScriptRoot "docker_build_inner.sh"
+docker run --rm `
+    -e CI=1 `
+    -e DOCKER_SKIP_SUBMODULES=1 `
+    -e WEBOS_NDL_LOW_LATENCY=1 `
+    -e DOCKER_CLEAN_BUILD=0 `
+    -v "${ProjectRoot}:/build" -v "${ScriptPath}:/docker_build.sh" -w /build ubuntu:22.04 `
+    bash -c "sed 's/\r$//' /docker_build.sh | bash"
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host ""
+    Write-Host "=== Low-latency build complete! ===" -ForegroundColor Green
+    Write-Host "Package in: $ProjectRoot\dist\" -ForegroundColor Cyan
+    Get-ChildItem "$ProjectRoot\dist\*_ll.ipk" -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "  $($_.Name)" }
+    Write-Host ""
+    Write-Host "Note: ss4s NDL sources were patched on disk. Before a normal build run:" -ForegroundColor Yellow
+    Write-Host "  git checkout third_party/ss4s" -ForegroundColor DarkGray
+} else {
+    Write-Host ""
+    Write-Host "Build failed." -ForegroundColor Red
+    exit 1
+}

--- a/scripts/webos/docker_build_inner.sh
+++ b/scripts/webos/docker_build_inner.sh
@@ -48,13 +48,34 @@ if [ ! -x "${SDK_ROOT}/bin/arm-webos-linux-gnueabi-gcc" ]; then
   exit 1
 fi
 # Build outside the Windows bind mount: cmake try_compile breaks on NTFS/exFAT volumes.
-export CMAKE_BINARY_DIR=/tmp/aurora-webos-build
+if [ "${WEBOS_NDL_LOW_LATENCY:-0}" = "1" ]; then
+    export CMAKE_BINARY_DIR="${CMAKE_BINARY_DIR:-/tmp/aurora-webos-build-ll}"
+    echo "=== NDL low-latency build (WEBOS_NDL_LOW_LATENCY=1) ==="
+else
+    export CMAKE_BINARY_DIR="${CMAKE_BINARY_DIR:-/tmp/aurora-webos-build}"
+fi
 if [ "${DOCKER_CLEAN_BUILD:-0}" = "1" ]; then
     rm -rf "${CMAKE_BINARY_DIR}"
 fi
 export CI=1
+export WEBOS_NDL_LOW_LATENCY
 sed 's/\r$//' ./scripts/webos/apply_ndl_low_latency.sh | bash
 sed 's/\r$//' ./scripts/webos/easy_build.sh | bash -s -- -DCMAKE_BUILD_TYPE=Release
 
 mkdir -p dist
 find "${CMAKE_BINARY_DIR}" -maxdepth 3 -name '*.ipk' -exec cp -f {} dist/ \;
+
+if [ "${WEBOS_NDL_LOW_LATENCY:-0}" = "1" ]; then
+    for ipk in dist/*.ipk; do
+        [ -f "${ipk}" ] || continue
+        case "${ipk}" in
+            *_ll.ipk) continue ;;
+        esac
+        ll_ipk="${ipk%.ipk}_ll.ipk"
+        mv -f "${ipk}" "${ll_ipk}"
+        echo "Low-latency package: ${ll_ipk}"
+    done
+    echo ""
+    echo "Note: NDL sources under third_party/ss4s were patched in the mounted tree."
+    echo "      Run 'git checkout third_party/ss4s' before a standard (non-LL) rebuild if needed."
+fi

--- a/src/app/lvgl/input/lv_sdl_drv_wheel_input.c
+++ b/src/app/lvgl/input/lv_sdl_drv_wheel_input.c
@@ -6,8 +6,27 @@
 #include "stream/session.h"
 #include "stream/session_events.h"
 #include "ui/root.h"
+#include "ui/ui_input.h"
+#include "lv_gridview.h"
 
 static void sdl_input_read(lv_indev_drv_t *drv, lv_indev_data_t *data);
+
+static bool wheel_handle_gridview(app_ui_input_t *input, const SDL_MouseWheelEvent *wheel) {
+    if (wheel->y == 0) {
+        return false;
+    }
+    lv_group_t *group = app_input_get_group(input);
+    if (group == NULL) {
+        return false;
+    }
+    lv_obj_t *focused = lv_group_get_focused(group);
+    if (focused == NULL || !lv_obj_check_type(focused, &lv_gridview_class)) {
+        return false;
+    }
+    /* Wheel down (y > 0) advances one page; wheel up goes back one page. */
+    lv_gridview_page(focused, wheel->y > 0);
+    return true;
+}
 
 int lv_sdl_init_wheel(lv_indev_drv_t *drv, app_ui_input_t *input) {
     lv_indev_drv_init(drv);
@@ -27,6 +46,8 @@ static void sdl_input_read(lv_indev_drv_t *drv, lv_indev_data_t *data) {
         app_t *app = input->ui->app;
         if (app->session != NULL && !ui_should_block_input()) {
             session_handle_input_event(app->session, &e);
+        } else if (wheel_handle_gridview(input, &e.wheel)) {
+            /* Page the game grid; do not move group focus or scroll parents. */
         } else if (e.wheel.y != 0) {
             /* Encoder scroll only: never set PRESSED — that triggers LVGL "encoder button" clicks. */
             data->enc_diff = (e.wheel.y > 0) ? -1 : 1;

--- a/src/app/ui/launcher/apps.controller.c
+++ b/src/app/ui/launcher/apps.controller.c
@@ -185,6 +185,7 @@ static lv_obj_t *apps_view(lv_fragment_t *self, lv_obj_t *container) {
     lv_obj_t *applist = controller->applist = lv_gridview_create(view);
     lv_obj_add_flag(applist, LV_OBJ_FLAG_EVENT_BUBBLE);
     lv_obj_set_scroll_dir(applist, LV_DIR_VER);
+    lv_obj_clear_flag(applist, LV_OBJ_FLAG_SCROLL_WITH_ARROW);
     lv_obj_set_scrollbar_mode(applist, LV_SCROLLBAR_MODE_ACTIVE);
     lv_obj_set_style_pad_hor(applist, lv_dpx(32), 0);
     lv_obj_set_style_pad_ver(applist, lv_dpx(28), 0);

--- a/src/app/ui/launcher/launcher.controller.c
+++ b/src/app/ui/launcher/launcher.controller.c
@@ -49,6 +49,16 @@ static void cb_detail_cancel(lv_event_t *event);
 
 static void cb_detail_key(lv_event_t *event);
 
+static void launcher_profile_dropdown_clicked(lv_event_t *event);
+
+static void launcher_profile_dropdown_key_preprocess(lv_event_t *event);
+
+static void launcher_profile_dropdown_key(lv_event_t *event);
+
+static void launcher_profile_dropdown_esc_preprocess(lv_event_t *event);
+
+static bool launcher_close_profile_dropdown(launcher_fragment_t *fragment, lv_obj_t *target);
+
 static void cb_server_btn_clicked(lv_event_t *event);
 
 static void open_manual_add(lv_event_t *event);
@@ -156,6 +166,7 @@ static void launcher_controller(lv_fragment_t *self, void *args) {
     fragment->first_created = true;
     fragment->launch_params = fargs->params;
     fragment->settings_fragment = NULL;
+    fragment->active_dropdown = NULL;
 }
 
 static void controller_dtor(lv_fragment_t *self) {
@@ -373,6 +384,108 @@ static void cb_detail_key(lv_event_t *event) {
     }
 }
 
+static bool launcher_close_profile_dropdown(launcher_fragment_t *fragment, lv_obj_t *target) {
+    lv_obj_t *dropdown = fragment->profile_dropdown;
+    if (dropdown == NULL) {
+        return false;
+    }
+    if (fragment->active_dropdown != dropdown && target != dropdown) {
+        return false;
+    }
+    if (!lv_dropdown_is_open(dropdown) && fragment->active_dropdown == NULL) {
+        return false;
+    }
+    fragment->active_dropdown = NULL;
+    if (lv_dropdown_is_open(dropdown)) {
+        lv_dropdown_close(dropdown);
+    }
+    lv_group_focus_obj(dropdown);
+    return true;
+}
+
+static void launcher_profile_dropdown_clicked(lv_event_t *event) {
+    launcher_fragment_t *fragment = lv_event_get_user_data(event);
+    lv_obj_t *target = lv_event_get_target(event);
+    if (lv_obj_has_state(target, LV_STATE_CHECKED)) {
+        fragment->active_dropdown = target;
+    } else {
+        fragment->active_dropdown = NULL;
+    }
+}
+
+static void launcher_profile_dropdown_esc_preprocess(lv_event_t *event) {
+    if (lv_event_get_code(event) != LV_EVENT_KEY || lv_event_get_key(event) != LV_KEY_ESC) {
+        return;
+    }
+    launcher_fragment_t *fragment = lv_event_get_user_data(event);
+    if (launcher_close_profile_dropdown(fragment, lv_event_get_target(event))) {
+        lv_event_stop_processing(event);
+    }
+}
+
+static void launcher_profile_dropdown_key_preprocess(lv_event_t *event) {
+    if (lv_event_get_code(event) != LV_EVENT_KEY) {
+        return;
+    }
+    launcher_fragment_t *fragment = lv_event_get_user_data(event);
+    lv_obj_t *target = lv_event_get_target(event);
+    if (target != fragment->profile_dropdown || fragment->active_dropdown) {
+        return;
+    }
+    switch (lv_event_get_key(event)) {
+        case LV_KEY_UP:
+            focus_detail(fragment);
+            lv_event_stop_processing(event);
+            return;
+        case LV_KEY_DOWN:
+            lv_event_stop_processing(event);
+            return;
+        case LV_KEY_LEFT:
+            lv_group_focus_prev(fragment->nav_group);
+            lv_event_stop_processing(event);
+            return;
+        case LV_KEY_RIGHT:
+            lv_group_focus_next(fragment->nav_group);
+            lv_event_stop_processing(event);
+            return;
+        default:
+            return;
+    }
+}
+
+static void launcher_profile_dropdown_key(lv_event_t *event) {
+    if (lv_event_get_code(event) != LV_EVENT_KEY) {
+        return;
+    }
+    launcher_fragment_t *fragment = lv_event_get_user_data(event);
+    if (!fragment->active_dropdown) {
+        return;
+    }
+    switch (lv_event_get_key(event)) {
+        case LV_KEY_UP:
+        case LV_KEY_DOWN:
+        case LV_KEY_LEFT:
+        case LV_KEY_RIGHT:
+            lv_event_stop_bubbling(event);
+            return;
+        default:
+            return;
+    }
+}
+
+void launcher_attach_profile_dropdown_nav(launcher_fragment_t *fragment) {
+    lv_obj_t *dropdown = fragment->profile_dropdown;
+    if (dropdown == NULL) {
+        return;
+    }
+    lv_obj_add_event_cb(dropdown, launcher_profile_dropdown_clicked, LV_EVENT_CLICKED, fragment);
+    lv_obj_add_event_cb(dropdown, launcher_profile_dropdown_key_preprocess,
+                        LV_EVENT_KEY | LV_EVENT_PREPROCESS, fragment);
+    lv_obj_add_event_cb(dropdown, launcher_profile_dropdown_key, LV_EVENT_KEY, fragment);
+    lv_obj_add_event_cb(dropdown, launcher_profile_dropdown_esc_preprocess,
+                        LV_EVENT_KEY | LV_EVENT_PREPROCESS, fragment);
+}
+
 static void cb_topbar_focused(lv_event_t *event) {
     launcher_fragment_t *controller = lv_event_get_user_data(event);
     if (!controller->pane_initialized) { return; }
@@ -381,6 +494,9 @@ static void cb_topbar_focused(lv_event_t *event) {
 
 static void cb_topbar_key(lv_event_t *event) {
     launcher_fragment_t *fragment = lv_event_get_user_data(event);
+    if (fragment->active_dropdown) {
+        return;
+    }
     switch (lv_event_get_key(event)) {
         case LV_KEY_LEFT: {
             lv_group_focus_prev(fragment->nav_group);

--- a/src/app/ui/launcher/launcher.controller.h
+++ b/src/app/ui/launcher/launcher.controller.h
@@ -27,6 +27,8 @@ typedef struct launcher_fragment_t {
     /* Detail area below the top bar; full width, hosts the apps fragment (game rail). */
     lv_obj_t *detail;
     lv_obj_t *profile_dropdown;
+    /** Profile combobox list open; blocks arrow-key focus changes until closed. */
+    lv_obj_t *active_dropdown;
 
     /* Server selector button shown in the top bar. Click opens the server popup
      * (full PC list with status icons, long-press for context menu). The label
@@ -73,5 +75,8 @@ void launcher_refresh_server_label(launcher_fragment_t *controller);
 
 /** After closing launcher-embedded UI, point keypad/gamepad focus back at the main bar. */
 void launcher_restore_nav_focus(launcher_fragment_t *controller);
+
+/** Wire gamepad/remote navigation for the top-bar profile combobox. */
+void launcher_attach_profile_dropdown_nav(launcher_fragment_t *controller);
 
 extern const lv_fragment_class_t launcher_controller_class;

--- a/src/app/ui/launcher/launcher.view.c
+++ b/src/app/ui/launcher/launcher.view.c
@@ -103,6 +103,7 @@ lv_obj_t *launcher_win_create(lv_fragment_t *self, lv_obj_t *parent) {
     lv_obj_set_style_max_width(controller->profile_dropdown, LV_DPX(160), 0);
     lv_obj_add_event_cb(controller->profile_dropdown, launcher_profile_changed, LV_EVENT_VALUE_CHANGED, controller);
     launcher_refresh_profile_dropdown(controller);
+    launcher_attach_profile_dropdown_nav(controller);
 
     /* Spacer that grows to push the action buttons to the right edge. */
     lv_obj_t *spacer = lv_obj_create(topbar);

--- a/src/app/ui/settings/panes/basic.pane.c
+++ b/src/app/ui/settings/panes/basic.pane.c
@@ -66,6 +66,8 @@ static void on_rename_profile_clicked(lv_event_t *e);
 
 static void on_delete_profile_clicked(lv_event_t *e);
 
+static void basic_pane_add_profile_section(basic_pane_t *pane, lv_obj_t *view);
+
 const lv_fragment_class_t settings_pane_basic_cls = {
     .constructor_cb = pane_ctor,
     .destructor_cb = pane_dtor,
@@ -96,38 +98,6 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     lv_obj_t *view = pref_pane_container(container);
     lv_obj_set_layout(view, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(view, LV_FLEX_FLOW_ROW_WRAP);
-
-    pref_title_label(view, locstr("Streaming profile"));
-    pane->profile_dropdown = lv_dropdown_create(view);
-    lv_obj_set_width(pane->profile_dropdown, LV_PCT(100));
-    refresh_profile_dropdown(pane);
-    lv_obj_add_event_cb(pane->profile_dropdown, on_profile_changed, LV_EVENT_VALUE_CHANGED, self);
-
-    lv_obj_t *profile_actions = lv_obj_create(view);
-    lv_obj_remove_style_all(profile_actions);
-    lv_obj_set_width(profile_actions, LV_PCT(100));
-    lv_obj_set_flex_flow(profile_actions, LV_FLEX_FLOW_ROW);
-    lv_obj_set_style_pad_column(profile_actions, lv_dpx(8), 0);
-
-    lv_obj_t *save_profile_btn = lv_btn_create(profile_actions);
-    lv_obj_t *save_profile_label = lv_label_create(save_profile_btn);
-    lv_label_set_text(save_profile_label, locstr("Save to profile"));
-    lv_obj_add_event_cb(save_profile_btn, on_save_profile_clicked, LV_EVENT_CLICKED, self);
-
-    lv_obj_t *new_profile_btn = lv_btn_create(profile_actions);
-    lv_obj_t *new_profile_label = lv_label_create(new_profile_btn);
-    lv_label_set_text(new_profile_label, locstr("New"));
-    lv_obj_add_event_cb(new_profile_btn, on_new_profile_clicked, LV_EVENT_CLICKED, self);
-
-    lv_obj_t *rename_profile_btn = lv_btn_create(profile_actions);
-    lv_obj_t *rename_profile_label = lv_label_create(rename_profile_btn);
-    lv_label_set_text(rename_profile_label, locstr("Rename"));
-    lv_obj_add_event_cb(rename_profile_btn, on_rename_profile_clicked, LV_EVENT_CLICKED, self);
-
-    lv_obj_t *delete_profile_btn = lv_btn_create(profile_actions);
-    lv_obj_t *delete_profile_label = lv_label_create(delete_profile_btn);
-    lv_label_set_text(delete_profile_label, locstr("Delete"));
-    lv_obj_add_event_cb(delete_profile_btn, on_delete_profile_clicked, LV_EVENT_CLICKED, self);
 
     pane->abr_checkbox = pref_checkbox(view, locstr("Adaptive bitrate"), &app_configuration->auto_adjust_bitrate, false);
     lv_obj_add_event_cb(pane->abr_checkbox, on_abr_changed, LV_EVENT_VALUE_CHANGED, self);
@@ -234,6 +204,8 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     update_bitrate_label(pane);
     update_bitrate_hint(pane);
 
+    basic_pane_add_profile_section(pane, view);
+
     return view;
 }
 
@@ -334,6 +306,41 @@ static void refresh_profile_dropdown(basic_pane_t *pane) {
     }
     lv_dropdown_set_options(pane->profile_dropdown, options[0] ? options : "Default");
     lv_dropdown_set_selected(pane->profile_dropdown, active_index);
+}
+
+static void basic_pane_add_profile_section(basic_pane_t *pane, lv_obj_t *view) {
+    pref_header(view, locstr("Streaming profile"));
+
+    pane->profile_dropdown = lv_dropdown_create(view);
+    lv_obj_set_width(pane->profile_dropdown, LV_PCT(100));
+    refresh_profile_dropdown(pane);
+    lv_obj_add_event_cb(pane->profile_dropdown, on_profile_changed, LV_EVENT_VALUE_CHANGED, pane);
+
+    lv_obj_t *profile_actions = lv_obj_create(view);
+    lv_obj_remove_style_all(profile_actions);
+    lv_obj_set_width(profile_actions, LV_PCT(100));
+    lv_obj_set_flex_flow(profile_actions, LV_FLEX_FLOW_ROW);
+    lv_obj_set_style_pad_column(profile_actions, lv_dpx(8), 0);
+
+    lv_obj_t *save_profile_btn = lv_btn_create(profile_actions);
+    lv_obj_t *save_profile_label = lv_label_create(save_profile_btn);
+    lv_label_set_text(save_profile_label, locstr("Save to profile"));
+    lv_obj_add_event_cb(save_profile_btn, on_save_profile_clicked, LV_EVENT_CLICKED, pane);
+
+    lv_obj_t *new_profile_btn = lv_btn_create(profile_actions);
+    lv_obj_t *new_profile_label = lv_label_create(new_profile_btn);
+    lv_label_set_text(new_profile_label, locstr("New"));
+    lv_obj_add_event_cb(new_profile_btn, on_new_profile_clicked, LV_EVENT_CLICKED, pane);
+
+    lv_obj_t *rename_profile_btn = lv_btn_create(profile_actions);
+    lv_obj_t *rename_profile_label = lv_label_create(rename_profile_btn);
+    lv_label_set_text(rename_profile_label, locstr("Rename"));
+    lv_obj_add_event_cb(rename_profile_btn, on_rename_profile_clicked, LV_EVENT_CLICKED, pane);
+
+    lv_obj_t *delete_profile_btn = lv_btn_create(profile_actions);
+    lv_obj_t *delete_profile_label = lv_label_create(delete_profile_btn);
+    lv_label_set_text(delete_profile_label, locstr("Delete"));
+    lv_obj_add_event_cb(delete_profile_btn, on_delete_profile_clicked, LV_EVENT_CLICKED, pane);
 }
 
 static void on_profile_changed(lv_event_t *e) {

--- a/src/app/ui/settings/settings.controller.c
+++ b/src/app/ui/settings/settings.controller.c
@@ -115,13 +115,7 @@ static void embed_popup_cancel_cb(lv_event_t *e);
 
 static void settings_dropdown_cancel_cb(lv_event_t *e);
 
-static bool settings_dropdown_list_open(settings_controller_t *c, lv_obj_t *target);
-
 static bool settings_close_dropdown_on_back(settings_controller_t *c, lv_obj_t *target);
-
-static lv_group_t *settings_nav_group_for(settings_controller_t *c);
-
-static void settings_dropdown_set_list_editing(settings_controller_t *c, bool editing);
 
 static void pane_child_attach_handlers(settings_controller_t *controller, lv_obj_t *child, bool popup);
 
@@ -394,70 +388,33 @@ static void on_detail_key(lv_event_t *e) {
                 }
                 return;
             case LV_KEY_ENTER:
-                if (lv_obj_has_class(target, &lv_dropdown_class)) {
-                    if (!lv_dropdown_is_open(target)) {
-                        lv_dropdown_open(target);
-                        controller->active_dropdown = target;
-                        settings_dropdown_set_list_editing(controller, true);
-                    }
-                    return;
-                }
                 if (lv_obj_check_type(target, &lv_textarea_class)) {
                     lv_group_set_editing(nav_detail, true);
-                    return;
                 }
                 return;
             case LV_KEY_UP:
-                if (settings_dropdown_list_open(controller, target)) {
-                    lv_event_stop_processing(e);
-                    return;
-                }
-                if (lv_obj_check_type(target, &lv_textarea_class) && lv_group_get_editing(nav_detail)) {
-                    return;
-                }
-                if (lv_obj_has_class(target, &lv_dropdown_class)) {
-                    lv_group_focus_prev(nav_detail);
-                    lv_event_stop_processing(e);
-                    return;
-                }
-                lv_group_focus_prev(nav_detail);
-                return;
             case LV_KEY_DOWN:
-                if (settings_dropdown_list_open(controller, target)) {
-                    lv_event_stop_processing(e);
+                if (controller->active_dropdown) {
+                    lv_event_stop_bubbling(e);
                     return;
                 }
                 if (lv_obj_check_type(target, &lv_textarea_class) && lv_group_get_editing(nav_detail)) {
                     return;
                 }
+                /* Closed dropdown arrows are handled in settings_dropdown_arrow_preprocess_cb. */
                 if (lv_obj_has_class(target, &lv_dropdown_class)) {
-                    lv_group_focus_next(nav_detail);
-                    lv_event_stop_processing(e);
                     return;
                 }
-                lv_group_focus_next(nav_detail);
+                if (key == LV_KEY_UP) {
+                    lv_group_focus_prev(nav_detail);
+                } else {
+                    lv_group_focus_next(nav_detail);
+                }
                 return;
             case LV_KEY_LEFT:
-                if (settings_dropdown_list_open(controller, target)) {
-                    lv_event_stop_processing(e);
-                    return;
-                }
-                if (lv_obj_check_type(target, &lv_textarea_class) && lv_group_get_editing(nav_detail)) {
-                    return;
-                }
-                if (detail_item_needs_lrkey(target)) {
-                    return;
-                }
-                if (lv_obj_has_class(target, &lv_dropdown_class)) {
-                    lv_group_focus_prev(nav_detail);
-                    lv_event_stop_processing(e);
-                    return;
-                }
-                lv_group_focus_prev(nav_detail);
-                return;
             case LV_KEY_RIGHT:
-                if (settings_dropdown_list_open(controller, target)) {
-                    lv_event_stop_processing(e);
+                if (controller->active_dropdown) {
+                    lv_event_stop_bubbling(e);
                     return;
                 }
                 if (lv_obj_check_type(target, &lv_textarea_class) && lv_group_get_editing(nav_detail)) {
@@ -467,11 +424,13 @@ static void on_detail_key(lv_event_t *e) {
                     return;
                 }
                 if (lv_obj_has_class(target, &lv_dropdown_class)) {
-                    lv_group_focus_next(nav_detail);
-                    lv_event_stop_processing(e);
                     return;
                 }
-                lv_group_focus_next(nav_detail);
+                if (key == LV_KEY_LEFT) {
+                    lv_group_focus_prev(nav_detail);
+                } else {
+                    lv_group_focus_next(nav_detail);
+                }
                 return;
             default:
                 return;
@@ -489,15 +448,6 @@ static void on_detail_key(lv_event_t *e) {
             break;
         }
         case LV_KEY_ENTER: {
-            if (lv_obj_has_class(target, &lv_dropdown_class)) {
-                if (!lv_dropdown_is_open(target)) {
-                    lv_dropdown_open(target);
-                    controller->active_dropdown = target;
-                    settings_dropdown_set_list_editing(controller, true);
-                }
-                lv_event_stop_bubbling(e);
-                break;
-            }
             if (lv_obj_check_type(target, &lv_textarea_class)) {
                 lv_group_set_editing(nav_detail, true);
                 lv_event_stop_bubbling(e);
@@ -505,27 +455,43 @@ static void on_detail_key(lv_event_t *e) {
             break;
         }
         case LV_KEY_UP: {
-            if (settings_dropdown_list_open(controller, target)) { return; }
+            if (controller->active_dropdown) {
+                lv_event_stop_bubbling(e);
+                return;
+            }
             lv_group_focus_prev(nav_detail);
             break;
         }
         case LV_KEY_DOWN: {
-            if (settings_dropdown_list_open(controller, target)) { return; }
+            if (controller->active_dropdown) {
+                lv_event_stop_bubbling(e);
+                return;
+            }
             lv_group_focus_next(nav_detail);
             break;
         }
         case LV_KEY_LEFT: {
-            if (detail_item_needs_lrkey(target)) { return; }
-            if (settings_dropdown_list_open(controller, target)) { return; }
+            if (detail_item_needs_lrkey(target)) {
+                return;
+            }
+            if (controller->active_dropdown) {
+                lv_event_stop_bubbling(e);
+                return;
+            }
             detail_defocus(controller, e);
             break;
         }
         case LV_KEY_RIGHT: {
-            if (detail_item_needs_lrkey(target)) { return; }
-            if (settings_dropdown_list_open(controller, target)) { return; }
-            if (lv_obj_has_class(target, &lv_dropdown_class)) {
-                lv_group_focus_next(nav_detail);
+            if (detail_item_needs_lrkey(target)) {
+                return;
+            }
+            if (controller->active_dropdown) {
                 lv_event_stop_bubbling(e);
+                return;
+            }
+            if (lv_obj_has_class(target, &lv_dropdown_class)) {
+                lv_dropdown_close(target);
+                controller->active_dropdown = NULL;
             }
             break;
         }
@@ -592,41 +558,50 @@ static void on_tab_content_key(lv_event_t *e) {
             break;
         }
         case LV_KEY_ENTER: {
-            if (lv_obj_has_class(target, &lv_dropdown_class)) {
-                if (!lv_dropdown_is_open(target)) {
-                    lv_dropdown_open(target);
-                    controller->active_dropdown = target;
-                    settings_dropdown_set_list_editing(controller, true);
-                }
-                return;
-            }
             if (lv_obj_check_type(target, &lv_textarea_class)) {
                 lv_group_set_editing(group, true);
-                return;
             }
             break;
         }
         case LV_KEY_DOWN: {
-            if (settings_dropdown_list_open(controller, target)) { return; }
-            if (lv_obj_get_parent(target) == controller->tabview) { return; }
+            if (controller->active_dropdown) {
+                lv_event_stop_bubbling(e);
+                return;
+            }
+            if (lv_obj_get_parent(target) == controller->tabview) {
+                return;
+            }
             lv_group_focus_next(group);
             break;
         }
         case LV_KEY_UP: {
-            if (settings_dropdown_list_open(controller, target)) { return; }
-            if (lv_obj_get_parent(target) == controller->tabview) { return; }
+            if (controller->active_dropdown) {
+                lv_event_stop_bubbling(e);
+                return;
+            }
+            if (lv_obj_get_parent(target) == controller->tabview) {
+                return;
+            }
             lv_group_focus_prev(group);
             break;
         }
         case LV_KEY_LEFT: {
-            if (detail_item_needs_lrkey(target)) { return; }
+            if (detail_item_needs_lrkey(target)) {
+                return;
+            }
             break;
         }
         case LV_KEY_RIGHT: {
-            if (detail_item_needs_lrkey(target)) { return; }
-            if (settings_dropdown_list_open(controller, target)) { return; }
+            if (detail_item_needs_lrkey(target)) {
+                return;
+            }
+            if (controller->active_dropdown) {
+                lv_event_stop_bubbling(e);
+                return;
+            }
             if (lv_obj_has_class(target, &lv_dropdown_class)) {
-                lv_group_focus_next(group);
+                lv_dropdown_close(target);
+                controller->active_dropdown = NULL;
             }
             break;
         }
@@ -661,10 +636,8 @@ static void on_dropdown_clicked(lv_event_t *event) {
     lv_obj_t *target = lv_event_get_target(event);
     if (lv_obj_has_state(target, LV_STATE_CHECKED)) {
         controller->active_dropdown = target;
-        settings_dropdown_set_list_editing(controller, true);
     } else {
         controller->active_dropdown = NULL;
-        settings_dropdown_set_list_editing(controller, false);
     }
 }
 
@@ -758,7 +731,6 @@ static void pane_child_attach_handlers(settings_controller_t *controller, lv_obj
     lv_obj_add_event_cb(child, on_detail_key, LV_EVENT_KEY, controller);
     if (lv_obj_has_class(child, &lv_dropdown_class)) {
         lv_obj_add_event_cb(child, on_dropdown_clicked, LV_EVENT_CLICKED, controller);
-        lv_obj_add_event_cb(child, on_dropdown_clicked, LV_EVENT_VALUE_CHANGED, controller);
         lv_obj_add_event_cb(child, settings_dropdown_arrow_preprocess_cb, LV_EVENT_KEY | LV_EVENT_PREPROCESS,
                             controller);
         if (popup) {
@@ -800,31 +772,6 @@ static void on_textarea_defocused(lv_event_t *e) {
     }
 }
 
-static lv_group_t *settings_nav_group_for(settings_controller_t *c) {
-    if (c->pane_popup_group) {
-        return c->pane_popup_group;
-    }
-    if (c->mini && c->tabview) {
-        uint16_t act = lv_tabview_get_tab_act(c->tabview);
-        return c->tab_groups[act];
-    }
-    return c->detail_group;
-}
-
-static void settings_dropdown_set_list_editing(settings_controller_t *c, bool editing) {
-    lv_group_t *group = settings_nav_group_for(c);
-    if (group != NULL) {
-        lv_group_set_editing(group, editing);
-    }
-}
-
-static bool settings_dropdown_list_open(settings_controller_t *c, lv_obj_t *target) {
-    if (c->active_dropdown != NULL && lv_dropdown_is_open(c->active_dropdown)) {
-        return true;
-    }
-    return target != NULL && lv_obj_has_class(target, &lv_dropdown_class) && lv_dropdown_is_open(target);
-}
-
 static bool settings_close_dropdown_on_back(settings_controller_t *c, lv_obj_t *target) {
     lv_obj_t *dropdown = NULL;
     if (c->active_dropdown != NULL) {
@@ -841,7 +788,6 @@ static bool settings_close_dropdown_on_back(settings_controller_t *c, lv_obj_t *
     }
     c->active_dropdown = NULL;
     c->suppress_pane_back = true;
-    settings_dropdown_set_list_editing(c, false);
     if (lv_dropdown_is_open(dropdown)) {
         lv_dropdown_close(dropdown);
     }
@@ -865,7 +811,7 @@ static void settings_dropdown_arrow_preprocess_cb(lv_event_t *e) {
     }
     settings_controller_t *c = lv_event_get_user_data(e);
     lv_obj_t *target = lv_event_get_target(e);
-    if (!lv_obj_has_class(target, &lv_dropdown_class) || settings_dropdown_list_open(c, target)) {
+    if (!lv_obj_has_class(target, &lv_dropdown_class) || c->active_dropdown) {
         return;
     }
     const uint32_t key = lv_event_get_key(e);
@@ -1162,6 +1108,7 @@ static void settings_show_pane_popup(settings_controller_t *c, const lv_fragment
     lv_obj_set_width(content, LV_PCT(100));
     lv_obj_set_style_max_height(content, LV_PCT(90), 0);
     lv_obj_set_style_pad_all(content, lv_dpx(12), 0);
+    lv_obj_clear_flag(content, LV_OBJ_FLAG_SCROLL_WITH_ARROW);
 
     c->pane_mbox = mbox;
     c->pane_popup_group = lv_group_create();


### PR DESCRIPTION
## Summary

- **Settings navigation:** Comboboxes, checkboxes, sliders, and text fields follow standard Moonlight-style gamepad navigation (open dropdowns on confirm, no hold-to-open, no background scroll while a list is open).
- **Basic Settings layout:** Streaming profile section moved to the bottom of the pane.
- **Launcher profile dropdown:** Directional keys no longer open the combobox; confirm opens it, Escape closes it.
- **Game grid:** Remote scroll wheel pages through visible rows; D-pad still moves one item at a time.
- **Docker builds:** Added `build_with_docker_ll.ps1` for optional NDL low-latency IPKs (`*_ll.ipk`); standard `build_with_docker.ps1` unchanged.
- **commons submodule:** Points to Aurora fork with `lv_gridview_page()` for wheel paging.

## Test plan

- [ ] Settings popup: open/close comboboxes with A and Escape; navigate options with UP/DOWN without scrolling the pane behind
- [ ] Launcher top bar: profile dropdown opens only on A; LEFT/RIGHT moves along the bar when closed
- [ ] Game grid: scroll wheel pages up/down; D-pad moves focus item-by-item
- [ ] `.\scripts\webos\build_with_docker.ps1` — standard IPK
- [ ] `.\scripts\webos\build_with_docker_ll.ps1` — `*_ll.ipk` output; verify latency on target TV