### PR TITLE
Fix GitHub license detection by restoring unmodified GPL-3.0 text.

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,12 @@
+Aurora (Moonlight TV for LG webOS)
+Copyright (C) 2024-2026 GuiDev1994 and contributors
+
+Based on moonlight-tv (C) mariotaku and contributors.
+https://github.com/mariotaku/moonlight-tv
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+See the LICENSE file for the full license text.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,3 @@
-Aurora (Moonlight TV for LG webOS)
-Copyright (C) 2024-2026 GuiDev1994 and contributors
-
-Based on moonlight-tv (C) mariotaku and contributors.
-See https://github.com/mariotaku/moonlight-tv
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License below for more details.
-
-------------------------------------------------------------------------
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,21 +1,3 @@
-Aurora (Moonlight TV for LG webOS)
-Copyright (C) 2024-2026 GuiDev1994 and contributors
-
-Based on moonlight-tv (C) mariotaku and contributors.
-See https://github.com/mariotaku/moonlight-tv
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License below for more details.
-
-------------------------------------------------------------------------
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/README.md
+++ b/README.md
@@ -62,4 +62,6 @@ Details, hotkey layout, and stats field reference: [webOS build guide](docs/BUIL
 
 This project is licensed under the [GNU General Public License v3.0](LICENSE) (GPL-3.0-or-later).
 
+Copyright and attribution details are in [COPYRIGHT](COPYRIGHT).
+
 Aurora is a fork of [moonlight-tv](https://github.com/mariotaku/moonlight-tv), which is also licensed under GPL-3.0.


### PR DESCRIPTION
GitHub requires LICENSE to start with the standard GPL header; move copyright and attribution to COPYRIGHT instead.