### PR TITLE
Adaptive bitrate robustness: bounded teardown, preset clamp, set-bitrate backoff, stats seqlock

### DIFF
--- a/core/libgamestream/libgamestream/client.h
+++ b/core/libgamestream/libgamestream/client.h
@@ -64,6 +64,10 @@ void gs_destroy(GS_CLIENT hnd);
 
 void gs_set_timeout(GS_CLIENT hnd, int timeout_secs);
 
+/* Whole-transfer ceiling on every request made through this client (see
+ * http_set_total_timeout); 0 = no ceiling (curl default). */
+void gs_set_total_timeout(GS_CLIENT hnd, int timeout_secs);
+
 int gs_get_status(GS_CLIENT hnd, PSERVER_DATA server, const char *address, uint16_t port, bool unsupported);
 
 int gs_start_app(GS_CLIENT hnd, PSERVER_DATA server, PSTREAM_CONFIGURATION config, int appId, bool is_gfe, bool sops,

--- a/core/libgamestream/libgamestream/http.h
+++ b/core/libgamestream/libgamestream/http.h
@@ -41,6 +41,8 @@ void http_destroy(HTTP *http);
 
 void http_set_timeout(HTTP *http, int timeout);
 
+void http_set_total_timeout(HTTP *http, int timeout);
+
 HTTP_DATA * http_data_alloc();
 
 void http_data_free(HTTP_DATA * data);

--- a/core/libgamestream/src/client.c
+++ b/core/libgamestream/src/client.c
@@ -786,6 +786,10 @@ void gs_set_timeout(GS_CLIENT hnd, int timeout_secs) {
     http_set_timeout(hnd->http, timeout_secs);
 }
 
+void gs_set_total_timeout(GS_CLIENT hnd, int timeout_secs) {
+    http_set_total_timeout(hnd->http, timeout_secs);
+}
+
 int gs_get_status(GS_CLIENT hnd, PSERVER_DATA server, const char *address, uint16_t port, bool unsupported) {
     LiInitializeServerInformation(&server->serverInfo);
     server->serverInfo.address = address;

--- a/core/libgamestream/src/http.c
+++ b/core/libgamestream/src/http.c
@@ -184,6 +184,16 @@ void http_set_timeout(HTTP *http, int timeout) {
     pthread_mutex_unlock(&http->mutex);
 }
 
+/* Whole-transfer ceiling (CURLOPT_TIMEOUT), not just connect: without one, a
+ * host that accepts the TCP connection and then hangs stalls the caller
+ * forever. 0 restores curl's default (no total timeout). */
+void http_set_total_timeout(HTTP *http, int timeout) {
+    assert(http != NULL);
+    pthread_mutex_lock(&http->mutex);
+    curl_easy_setopt(http->curl, CURLOPT_TIMEOUT, (long) timeout);
+    pthread_mutex_unlock(&http->mutex);
+}
+
 HTTP_DATA *http_data_alloc() {
     HTTP_DATA *data = malloc(sizeof(HTTP_DATA));
     assert(data != NULL);

--- a/src/app/stream/adaptive_bitrate.c
+++ b/src/app/stream/adaptive_bitrate.c
@@ -30,6 +30,11 @@ struct adaptive_bitrate_service {
     int stable_seconds;
     int loss_streak;
     Uint32 last_adjust_ticks;
+    /* Backoff for failing gs_set_bitrate calls (host without the /bitrate
+     * endpoint, or transiently unreachable): each failed set doubles the pause
+     * up to 30s so we don't burn a fresh TLS handshake every adjust attempt. */
+    int set_fail_streak;
+    Uint32 set_backoff_until;
 };
 
 const char *abr_mode_to_string(abr_mode_t mode) {
@@ -84,10 +89,25 @@ static bool abr_set_bitrate(adaptive_bitrate_service_t *service, int kbps, const
     if (kbps == service->current_bitrate) {
         return false;
     }
-    int from = service->current_bitrate;
-    if (gs_set_bitrate(service->gs_client, &service->server_copy, kbps) != GS_OK) {
+    Uint32 now = SDL_GetTicks();
+    if (service->set_backoff_until != 0 && now < service->set_backoff_until) {
         return false;
     }
+    int from = service->current_bitrate;
+    if (gs_set_bitrate(service->gs_client, &service->server_copy, kbps) != GS_OK) {
+        if (service->set_fail_streak < 5) {
+            service->set_fail_streak++;
+        }
+        Uint32 delay = 2000u << (service->set_fail_streak - 1);   /* 2/4/8/16/30s */
+        if (delay > 30000u) {
+            delay = 30000u;
+        }
+        service->set_backoff_until = now + delay;
+        commons_log_warn("ABR", "[%s] set %d kbps failed; backing off %u ms", source, kbps, delay);
+        return false;
+    }
+    service->set_fail_streak = 0;
+    service->set_backoff_until = 0;
     service->current_bitrate = kbps;
     commons_log_info("ABR", "[%s] %d kbps -> %d kbps", source, from, kbps);
     return true;
@@ -261,6 +281,7 @@ void adaptive_bitrate_stop(adaptive_bitrate_service_t *service, bool restore) {
      * anyway, so a missed restore is harmless. */
     if (restore) {
         gs_set_total_timeout(service->gs_client, 2);
+        service->set_backoff_until = 0;   /* a clean restore must not be skipped by backoff */
         if (service->current_bitrate != service->initial_bitrate) {
             abr_set_bitrate(service, service->initial_bitrate, "restore");
         }

--- a/src/app/stream/adaptive_bitrate.c
+++ b/src/app/stream/adaptive_bitrate.c
@@ -222,6 +222,10 @@ adaptive_bitrate_service_t *adaptive_bitrate_start(const adaptive_bitrate_config
     service->current_bitrate = config->initial_bitrate;
     service->mode = config->mode;
     abr_apply_mode_preset(service);
+    /* The GS_CLIENT only has a connect timeout; cap whole transfers too so an
+     * in-flight ABR tick can never stall stop's SDL_WaitThread for long (a
+     * half-open host would otherwise hang a request indefinitely). */
+    gs_set_total_timeout(service->gs_client, 5);
     SDL_AtomicSet(&service->stop, 0);
     service->thread = SDL_CreateThread(abr_thread, "abr", service);
     if (!service->thread) {
@@ -236,7 +240,7 @@ adaptive_bitrate_service_t *adaptive_bitrate_start(const adaptive_bitrate_config
     return service;
 }
 
-void adaptive_bitrate_stop(adaptive_bitrate_service_t *service) {
+void adaptive_bitrate_stop(adaptive_bitrate_service_t *service, bool restore) {
     if (!service) {
         return;
     }
@@ -244,12 +248,20 @@ void adaptive_bitrate_stop(adaptive_bitrate_service_t *service) {
     if (service->thread) {
         SDL_WaitThread(service->thread, NULL);
     }
-    if (service->current_bitrate != service->initial_bitrate) {
-        abr_set_bitrate(service, service->initial_bitrate, "restore");
-    }
-    if (service->server_supported) {
-        GS_ABR_CONFIG config = {.enabled = false, .min_bitrate = 0, .max_bitrate = 0, .mode = "balanced"};
-        gs_set_abr_mode(service->gs_client, &service->server_copy, &config);
+    /* This runs on the session thread during teardown: only talk to the host
+     * on a clean exit (error/disconnect means it is likely unreachable and
+     * every call below would block on a timeout), and keep even the clean
+     * path short -- the host resets per-session bitrate on the next launch
+     * anyway, so a missed restore is harmless. */
+    if (restore) {
+        gs_set_total_timeout(service->gs_client, 2);
+        if (service->current_bitrate != service->initial_bitrate) {
+            abr_set_bitrate(service, service->initial_bitrate, "restore");
+        }
+        if (service->server_supported) {
+            GS_ABR_CONFIG config = {.enabled = false, .min_bitrate = 0, .max_bitrate = 0, .mode = "balanced"};
+            gs_set_abr_mode(service->gs_client, &service->server_copy, &config);
+        }
     }
     free((void *) service->server_copy.uuid);
     free((void *) service->server_copy.mac);

--- a/src/app/stream/adaptive_bitrate.c
+++ b/src/app/stream/adaptive_bitrate.c
@@ -179,7 +179,12 @@ static int abr_thread(void *userdata) {
             continue;
         }
 
-        const struct VIDEO_STATS *stats = &vdec_summary_stats;
+        /* Tear-free snapshot: the session thread rewrites vdec_summary_stats
+         * every 1-2s; the seqlock retry in vdec_stats_snapshot guarantees a
+         * consistent copy (a torn read here could cause a spurious 30% cut). */
+        struct VIDEO_STATS stats_snap;
+        vdec_stats_snapshot(&stats_snap);
+        const struct VIDEO_STATS *stats = &stats_snap;
         float packet_loss = stats->totalFrames > 0
             ? (float) stats->networkDroppedFrames / (float) stats->totalFrames * 100.0f
             : 0.0f;

--- a/src/app/stream/adaptive_bitrate.c
+++ b/src/app/stream/adaptive_bitrate.c
@@ -72,6 +72,12 @@ static void abr_apply_mode_preset(adaptive_bitrate_service_t *service) {
             }
             break;
     }
+    /* Low initial bitrates can invert the presets (e.g. QUALITY at 3000 kbps
+     * gives min=5000 > max=4500); the tick's clamp order would then RAISE the
+     * bitrate above the user's setting. Normalize so max always wins. */
+    if (service->min_bitrate > service->max_bitrate) {
+        service->min_bitrate = service->max_bitrate;
+    }
 }
 
 static bool abr_set_bitrate(adaptive_bitrate_service_t *service, int kbps, const char *source) {

--- a/src/app/stream/adaptive_bitrate.h
+++ b/src/app/stream/adaptive_bitrate.h
@@ -22,6 +22,9 @@ typedef struct {
 
 adaptive_bitrate_service_t *adaptive_bitrate_start(const adaptive_bitrate_config_t *config);
 
-void adaptive_bitrate_stop(adaptive_bitrate_service_t *service);
+/* restore=false skips the bitrate-restore / server-disable HTTP round-trips --
+ * used when the session ended in error/disconnect and the host is likely
+ * unreachable (each call would otherwise block teardown on a timeout). */
+void adaptive_bitrate_stop(adaptive_bitrate_service_t *service, bool restore);
 
 const char *abr_mode_to_string(abr_mode_t mode);

--- a/src/app/stream/session_worker.c
+++ b/src/app/stream/session_worker.c
@@ -140,7 +140,10 @@ int session_worker(session_t *session) {
     // Don't always reset status as error state should be kept
     session_set_state(session, STREAMING_NONE);
     thread_cleanup:
-    adaptive_bitrate_stop(session->abr);
+    /* Restore only on a clean exit: streaming_errno != GS_OK means the session
+     * ended in error/disconnect and the host is likely unreachable -- the
+     * restore round-trips would just block teardown on timeouts. */
+    adaptive_bitrate_stop(session->abr, streaming_errno == GS_OK);
     session->abr = NULL;
     session_connection_callbacks_reset(session);
     if (session->player != NULL) {

--- a/src/app/stream/video/session_video.c
+++ b/src/app/stream/video/session_video.c
@@ -52,6 +52,9 @@ static struct VIDEO_STATS vdec_temp_stats;
 static int vdec_stream_format = 0;
 static bool vdec_warned_near_buffer_limit;
 VIDEO_STATS vdec_summary_stats;
+/* Seqlock for vdec_summary_stats: odd while vdec_stat_submit is mid-write.
+ * Single writer (session thread); cross-thread readers use vdec_stats_snapshot. */
+static unsigned vdec_stats_seq;
 VIDEO_INFO vdec_stream_info;
 
 static int vdec_delegate_setup(int videoFormat, int width, int height, int redrawRate, void *context, int drFlags);
@@ -293,11 +296,35 @@ int vdec_delegate_submit(PDECODE_UNIT decodeUnit) {
     }
 }
 
+static inline void vdec_stats_write_begin(void) {
+    vdec_stats_seq++; /* odd: write in progress */
+    __atomic_thread_fence(__ATOMIC_RELEASE);
+}
+
+static inline void vdec_stats_write_end(void) {
+    __atomic_thread_fence(__ATOMIC_RELEASE);
+    vdec_stats_seq++; /* even: consistent */
+}
+
+void vdec_stats_snapshot(struct VIDEO_STATS *out) {
+    unsigned s1, s2;
+    do {
+        s1 = __atomic_load_n(&vdec_stats_seq, __ATOMIC_ACQUIRE);
+        memcpy(out, &vdec_summary_stats, sizeof(*out));
+        __atomic_thread_fence(__ATOMIC_ACQUIRE);
+        s2 = __atomic_load_n(&vdec_stats_seq, __ATOMIC_RELAXED);
+    } while ((s1 & 1u) != 0 || s1 != s2);
+}
+
 void vdec_stat_submit(const struct VIDEO_STATS *src, unsigned long now) {
     struct VIDEO_STATS *dst = &vdec_summary_stats;
+    vdec_stats_write_begin();
     memcpy(dst, src, sizeof(struct VIDEO_STATS));
     unsigned long delta = now - dst->measurementStartTimestamp;
-    if (delta <= 0) { return; }
+    if (delta <= 0) {
+        vdec_stats_write_end();
+        return;
+    }
     dst->totalFps = (float) dst->totalFrames / ((float) delta / 1000);
     dst->receivedFps = (float) dst->receivedFrames / ((float) delta / 1000);
     dst->decodedFps = (float) dst->submittedFrames / ((float) delta / 1000);
@@ -307,6 +334,7 @@ void vdec_stat_submit(const struct VIDEO_STATS *src, unsigned long now) {
         LiGetEstimatedRttInfo(&dst->rtt, &dst->rttVariance);
     }
     if (!show_stats) {
+        vdec_stats_write_end();
         return;
     }
     int latencyUs = 0;
@@ -316,6 +344,7 @@ void vdec_stat_submit(const struct VIDEO_STATS *src, unsigned long now) {
     } else {
         dst->avgDecoderLatency = 0;
     }
+    vdec_stats_write_end();
     app_bus_post(session->app, (bus_actionfunc) streaming_refresh_stats, NULL);
 }
 

--- a/src/app/stream/video/session_video.h
+++ b/src/app/stream/video/session_video.h
@@ -8,6 +8,9 @@ extern struct AUDIO_INFO audio_stream_info;
 
 extern DECODER_RENDERER_CALLBACKS ss4s_dec_callbacks;
 
+/** Tear-free copy of vdec_summary_stats for cross-thread readers (seqlock retry). */
+void vdec_stats_snapshot(struct VIDEO_STATS *out);
+
 /** Call before LiStartConnection. Sets decoder capabilities from settings (RFI + slices for HEVC when enabled). */
 void session_video_prepare_stream(void);
 


### PR DESCRIPTION
Four robustness fixes for the Adaptive Bitrate feature shipped in v1.1.0. All of them target real failure modes in the code under `src/app/stream/adaptive_bitrate.c` (plus the stats it reads and the libgamestream client it drives). Each fix is its own commit.

### 1. Bound the ABR teardown so a dead host can't hang the stream exit
`adaptive_bitrate_stop()` runs on the session thread during teardown and makes synchronous HTTPS round-trips (bitrate restore + server-side ABR disable). The `GS_CLIENT` only ever set `CURLOPT_CONNECTTIMEOUT`, so when a stream ends because the **host died**, the socket is half-open: curl completes the TCP handshake and then waits indefinitely. The ABR worker's own in-flight tick has the same problem, so `SDL_WaitThread` plus the two restore calls could stall the exit for many seconds.

Fix: a new `gs_set_total_timeout()`/`http_set_total_timeout()` exposes `CURLOPT_TIMEOUT` (a whole-transfer ceiling, not just connect). The ABR worker caps its transfers at 5s, and `adaptive_bitrate_stop()` gains a `restore` flag. The session worker passes `restore = (streaming_errno == GS_OK)`: on an error/disconnect exit the host is likely unreachable, so the restore/disable calls are skipped entirely; the clean path still runs them but under a 2s ceiling. A missed restore is harmless — the host resets per-session bitrate on the next launch.

### 2. Clamp presets so `min_bitrate` never exceeds `max_bitrate`
The mode presets derive min/max from the initial bitrate and can invert at low bitrates: e.g. `QUALITY` at 3000 kbps floors `min` at 5000 while `max` is only 4500. The per-tick clamp applies `min` after `max`, so an inverted range **raises** the streamed bitrate above the value the user configured. Fix: clamp `min` down to `max` after each preset.

### 3. Back off after failed set-bitrate requests
`gs_set_bitrate()` opens a fresh TLS connection (`FORBID_REUSE`) per call. When the host rejects the request or lacks the endpoint, the tick retried every 1–2s, burning a full failing handshake on every adjust. Fix: track a failure streak and pause new attempts with exponential backoff (2/4/8/16/30s), reset on the first success. The stop path clears the backoff before its restore call so a clean teardown is never skipped.

### 4. Serialize `vdec_summary_stats` reads with a seqlock
`vdec_stat_submit()` rewrites `vdec_summary_stats` in place on the session thread every 1–2s, while the ABR thread reads it once per tick with no synchronization. A tick landing mid-write can pair a new-window `totalFrames` with an old-window `networkDroppedFrames` and compute bogus packet loss — enough for a single spurious 30% cut before the probe path recovers. Fix: a minimal seqlock (single writer flips an odd/even counter around the update; readers snapshot via `vdec_stats_snapshot()` and retry). The UI stats overlay still reads directly, where a one-frame tear is only cosmetic.

---

I couldn't run a full webOS cross-compile here, so these rely on CI / your build for final verification; the edits reference only existing symbols (`streaming_errno`, `GS_OK`, `commons_log_warn`, the ABR service struct, the preset fields, `vdec_summary_stats`, `vdec_stat_submit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
