### PR TITLE
fix: inverted wheel scroll direction, and animate instantly instead of per-tick

### DIFF
--- a/src/app/lvgl/input/lv_sdl_drv_wheel_input.c
+++ b/src/app/lvgl/input/lv_sdl_drv_wheel_input.c
@@ -59,7 +59,11 @@ static bool wheel_handle_scrollable(app_ui_input_t *input, const SDL_MouseWheelE
                      * further/later content, same direction as paging forward. */
                     const lv_coord_t step = LV_MAX(lv_dpx(48), lv_obj_get_height(scrollable) / 6);
                     const lv_coord_t dy = (wheel->y > 0) ? step : -step;
-                    lv_obj_scroll_by_bounded(scrollable, 0, dy, LV_ANIM_ON);
+                    /* LV_ANIM_OFF: track wheel input directly instead of queuing a
+                     * ~200-400ms animated hop per tick, which felt sluggish/laggy
+                     * when scrolling quickly (browser/native scrolling doesn't
+                     * animate each discrete wheel tick either). */
+                    lv_obj_scroll_by_bounded(scrollable, 0, dy, LV_ANIM_OFF);
                     return true;
                 }
             }

--- a/src/app/lvgl/input/lv_sdl_drv_wheel_input.c
+++ b/src/app/lvgl/input/lv_sdl_drv_wheel_input.c
@@ -54,9 +54,11 @@ static bool wheel_handle_scrollable(app_ui_input_t *input, const SDL_MouseWheelE
                 const lv_coord_t overflow =
                         lv_obj_get_scroll_top(scrollable) + lv_obj_get_scroll_bottom(scrollable);
                 if (overflow > 0) {
-                    /* SDL: y > 0 = away (scroll up). LVGL: positive dy scrolls content down. */
+                    /* Confirmed inverted on-device with the original mapping. Match
+                     * wheel_handle_gridview's convention: wheel down (y > 0) reveals
+                     * further/later content, same direction as paging forward. */
                     const lv_coord_t step = LV_MAX(lv_dpx(48), lv_obj_get_height(scrollable) / 6);
-                    const lv_coord_t dy = (wheel->y > 0) ? -step : step;
+                    const lv_coord_t dy = (wheel->y > 0) ? step : -step;
                     lv_obj_scroll_by_bounded(scrollable, 0, dy, LV_ANIM_ON);
                     return true;
                 }
@@ -91,7 +93,10 @@ static void sdl_input_read(lv_indev_drv_t *drv, lv_indev_data_t *data) {
             /* Scroll settings / host lists instead of changing focus. */
         } else if (e.wheel.y != 0) {
             /* Encoder scroll only: never set PRESSED — that triggers LVGL "encoder button" clicks. */
-            data->enc_diff = (e.wheel.y > 0) ? -1 : 1;
+            /* Fallback for lists that fit without overflow (wheel_handle_scrollable above only
+             * fires when there's actual scroll room). Match wheel_handle_gridview's convention:
+             * wheel down (y > 0) should move focus forward/down (positive enc_diff). */
+            data->enc_diff = (e.wheel.y > 0) ? 1 : -1;
         }
     }
     data->continue_reading = false;


### PR DESCRIPTION
**In short, reversed the inverted scroll direction for the menu, and made it snappier.**

Two commits, stacked:

1. Two code paths handle wheel scrolling for settings panes and host lists: wheel_handle_scrollable() for lists that overflow their visible area, and an enc_diff (LVGL encoder) fallback for lists that fit without needing to scroll. Both had their sign backwards relative to wheel_handle_gridview's established convention (wheel down / y > 0 reveals forward/later content) -- confirmed and fixed on-device.
2. wheel_handle_scrollable() scrolled with LV_ANIM_ON, queuing a ~200-400ms animation per wheel tick. Scrolling quickly outpaced the animation, feeling sluggish/laggy compared to native/browser scrolling, which tracks input directly rather than animating each discrete tick. Switched to LV_ANIM_OFF.