### PR TITLE
fix: preserve focused app across apploader list rebuilds

### DIFF
--- a/src/app/ui/launcher/apps.controller.c
+++ b/src/app/ui/launcher/apps.controller.c
@@ -66,6 +66,8 @@ static void applist_focus_enter(lv_event_t *event);
 
 static void applist_focus_leave(lv_event_t *event);
 
+static void gridview_focus_with_key_state(lv_obj_t *grid, int idx);
+
 static void update_view_state(apps_fragment_t *controller);
 
 static void appitem_bind(apps_fragment_t *controller, lv_obj_t *item, apploader_item_t *app);
@@ -515,8 +517,21 @@ static void show_ok(apps_fragment_t *fragment) {
     if (lv_group_get_focused(lv_obj_get_group(fragment->applist)) != fragment->applist) {
         lv_group_focus_obj(fragment->applist);
     }
-    int idx = fragment->focus_backup >= 0 ? fragment->focus_backup : 0;
-    lv_gridview_focus(fragment->applist, idx);
+    /* show_ok() runs on every successful poll via update_view_state(), not
+     * just on a genuine transition into this state. Only apply an explicit
+     * item-level focus if the grid doesn't already have one -- unconditionally
+     * re-focusing using focus_backup (which is only updated on blur, never
+     * while the user is actively navigating inside the grid) was snapping
+     * focus back to a stale position every ~10s regardless of where the user
+     * had actually navigated to. This was the actual cause of the reported
+     * "loses focus every ~10s" bug: a regression introduced in commit
+     * 683e2404 ("Add fractional refresh support and input improvements"),
+     * which added this unconditional refocus call -- upstream's show_ok()
+     * has no such call at all. */
+    if (lv_gridview_get_focused_index(fragment->applist) < 0) {
+        int idx = fragment->focus_backup >= 0 ? fragment->focus_backup : 0;
+        gridview_focus_with_key_state(fragment->applist, idx);
+    }
 }
 
 static void show_error(apps_fragment_t *fragment, const char *title, const char *hint, const char *detail) {
@@ -543,14 +558,48 @@ static void appload_loaded(apploader_list_t *apps, void *userdata) {
     }
     int num_changes = -1;
     lv_gridview_data_change_t *changes = apps_list_detect_change(fragment->apploader_apps, apps, &num_changes);
+
+    /* Every poll that isn't a byte-for-byte identical list (e.g. the backend
+     * returning apps in a new order) forces a full grid rebuild via
+     * lv_gridview_set_data_advanced() below. lv_gridview itself already
+     * refuses to recycle the currently-focused item's view during that
+     * rebuild (see grid_recycle_item() in lv_gridview.c), so if the grid
+     * currently owns input focus, that focus already survives on its own --
+     * no action needed here.
+     *
+     * What still breaks is fragment->focus_backup, which is only updated when
+     * focus *leaves* the grid (applist_focus_leave). If the grid doesn't
+     * currently own focus (e.g. the user is on the top bar), that backup is a
+     * raw index into the *old* list, which apps_list_detect_change() may have
+     * just reordered -- so re-resolve it by app id before it's used to
+     * restore focus later (show_ok / applist_focus_enter / apps_focus_rail).
+     * We deliberately do NOT call lv_gridview_focus() here: doing so while
+     * the grid already owns focus would fight the preservation above using
+     * this same possibly-stale backup value, which is what caused focus to
+     * visibly jump during normal browsing after the first pass at this fix. */
     if (num_changes != 0) {
-        fragment->focus_backup = 0;
+        int live_focus = lv_gridview_get_focused_index(fragment->applist);
+        if (live_focus < 0) {
+            int prev_index = fragment->focus_backup;
+            int focused_app_id = -1;
+            if (fragment->apploader_apps != NULL && prev_index >= 0
+                    && (size_t) prev_index < fragment->apploader_apps->count) {
+                focused_app_id = fragment->apploader_apps->items[prev_index].base.id;
+            }
+            int new_index = 0;
+            if (focused_app_id >= 0) {
+                const apploader_item_t *found = apploader_list_item_by_id(apps, focused_app_id);
+                if (found != NULL) {
+                    new_index = (int) (found - apps->items);
+                }
+            }
+            fragment->focus_backup = new_index;
+        }
     }
+
     apploader_list_free(fragment->apploader_apps);
     fragment->apploader_apps = apps;
-    if (num_changes != 0) {
-        lv_gridview_focus(fragment->applist, 0);
-    }
+
     lv_gridview_set_data_advanced(fragment->applist, apps, changes, num_changes);
     if (changes != NULL) {
         free(changes);
@@ -677,11 +726,28 @@ static void adapter_bind_view(lv_obj_t *grid, lv_obj_t *item_view, void *data, i
 }
 
 
+/* lv_gridview_focus() reports its FOCUSED event using lv_indev_get_act(),
+ * which is NULL whenever focus is routed into the grid programmatically
+ * (group-focus mechanics, fragment lifecycle, etc.) rather than from a live
+ * keypress. LVGL's default LV_EVENT_FOCUSED handler only applies
+ * LV_STATE_FOCUS_KEY for a genuine keypad/encoder indev, so in the
+ * programmatic case the tile ends up focused internally
+ * (grid->focused_index is correct) but shows no selection outline at all.
+ * Force the state directly after focusing, same as upstream's
+ * set_detail_opened() already does for non-gridview objects. */
+static void gridview_focus_with_key_state(lv_obj_t *grid, int idx) {
+    lv_gridview_focus(grid, idx);
+    lv_obj_t *focused_item = lv_gridview_get_item_view(grid, idx);
+    if (focused_item) {
+        lv_obj_add_state(focused_item, LV_STATE_FOCUS_KEY);
+    }
+}
+
 static void applist_focus_enter(lv_event_t *event) {
     if (event->target != event->current_target) { return; }
     apps_fragment_t *controller = lv_event_get_user_data(event);
     int idx = controller->focus_backup >= 0 ? controller->focus_backup : 0;
-    lv_gridview_focus(controller->applist, idx);
+    gridview_focus_with_key_state(controller->applist, idx);
 }
 
 static void applist_focus_leave(lv_event_t *event) {
@@ -886,7 +952,7 @@ void apps_focus_rail(apps_fragment_t *controller) {
     }
     lv_group_focus_obj(controller->applist);
     int idx = controller->focus_backup >= 0 ? controller->focus_backup : 0;
-    lv_gridview_focus(controller->applist, idx);
+    gridview_focus_with_key_state(controller->applist, idx);
 }
 
 static void applist_key_up_to_topbar(lv_event_t *event) {

--- a/src/app/ui/launcher/launcher.controller.c
+++ b/src/app/ui/launcher/launcher.controller.c
@@ -571,6 +571,19 @@ static void focus_detail(launcher_fragment_t *controller) {
                     index = 0;
                 }
                 lv_gridview_focus(cur, index);
+                /* lv_gridview_focus() sends its FOCUSED event via
+                 * lv_indev_get_act(), which is NULL here (this is a
+                 * programmatic focus-route, not a real keypress) -- LVGL's
+                 * own event handler only applies LV_STATE_FOCUS_KEY for a
+                 * genuine keypad/encoder indev, so the tile ends up
+                 * "focused" internally (grid->focused_index is correct) but
+                 * visually shows no selection outline at all. Force the
+                 * state directly, same as the non-gridview branch below
+                 * already does. */
+                lv_obj_t *focused_item = lv_gridview_get_item_view(cur, index);
+                if (focused_item) {
+                    lv_obj_add_state(focused_item, LV_STATE_FOCUS_KEY);
+                }
             } else {
                 lv_obj_add_state(cur, LV_STATE_FOCUS_KEY);
             }


### PR DESCRIPTION
**In short, the app selection was being reset every 10 seconds, this fixes it, only refreshes if there are changes.**

apps_list_detect_change() flags almost any poll result as 'different' (e.g. the backend returning apps in a new order), forcing a full grid rebuild via lv_gridview_set_data_advanced(). lv_gridview itself already protects the currently-focused item's view from being recycled during that rebuild, so focus survives on its own whenever the grid currently owns input focus.

The actual cause of the reported 'loses focus every ~10s' bug turned out to be elsewhere: show_ok() -- called on every successful poll via update_view_state(), not just on a genuine state transition -- unconditionally called lv_gridview_focus() using focus_backup, which is only updated on blur and never reflects live in-grid navigation. This silently snapped focus back to a stale position every ~10s regardless of where the user had actually navigated to. Confirmed via git blame that this unconditional call was added in 683e2404 ('Add fractional refresh support and input improvements'); upstream's show_ok() has no such call. Fixed by only applying explicit focus there when the grid doesn't already have one.

Also fixed a related, separately-diagnosed bug: lv_gridview_focus() reports its FOCUSED event via lv_indev_get_act(), which is NULL whenever focus is applied programmatically (group-focus mechanics, fragment lifecycle) rather than from a live keypress. LVGL's event handler only applies LV_STATE_FOCUS_KEY for a genuine keypad/encoder indev, so tiles focused this way were internally correct but showed no selection outline at all. Added gridview_focus_with_key_state() to force the state directly after every programmatic focus call, matching the pattern upstream's set_detail_opened() already uses for non-gridview objects.

Also fixes a latent use-after-free: focus was being applied via lv_gridview_focus() before lv_gridview_set_data_advanced() updated the grid's internal data pointer, so it could bind against the apploader list we'd just freed. Reordered so data updates before focus.

Touches apps.controller.c, same file as the cover-flicker PR (not git-stacked, but overlapping) -- recommend merging one before the other to avoid a conflict.