### PR TITLE
fix: stop game grid cover art flickering on every poll

### DIFF
--- a/src/app/ui/launcher/apps.controller.c
+++ b/src/app/ui/launcher/apps.controller.c
@@ -582,8 +582,18 @@ static void appload_errored(int code, const char *error, void *userdata) {
 static void appitem_bind(apps_fragment_t *controller, lv_obj_t *item, apploader_item_t *app) {
     appitem_viewholder_t *holder = lv_obj_get_user_data(item);
 
-    coverloader_display(controller->coverloader, &controller->uuid, app->base.id, item,
-                        controller->col_width, controller->col_height);
+    /* lv_gridview's fill_rows() rebinds every visible tile on every single
+     * lv_gridview_set_data_advanced() call, including when the view wasn't
+     * recycled and is already showing this exact app (e.g. every ~10s poll
+     * that finds nothing changed). coverloader_display() unconditionally
+     * cancels any in-flight load and kicks off a new one, which redraws the
+     * cover art even when it's already correct -- that's what caused the
+     * cover art to visibly flicker on every poll. Skip it when this view is
+     * already displaying the right app's cover. */
+    if (holder->app_id != app->base.id) {
+        coverloader_display(controller->coverloader, &controller->uuid, app->base.id, item,
+                            controller->col_width, controller->col_height);
+    }
     lv_label_set_text(holder->title, app->base.name);
 
     int current_id = pcmanager_server_current_app(pcmanager, &controller->uuid);
@@ -846,7 +856,13 @@ static lv_gridview_data_change_t *apps_list_detect_change(const apploader_list_t
                                                           const apploader_list_t *new_list, int *num_changes) {
     if (old_list == NULL && new_list == NULL) {
         *num_changes = 0;
-        return NULL;
+        /* Must be non-NULL: lv_gridview_set_data_advanced() treats a NULL
+         * changes pointer as "invalidate everything" regardless of
+         * num_changes (see its `changes == NULL || num_changes < 0` check),
+         * so a genuinely-empty change set still needs a real (if unused)
+         * pointer to avoid a full, unnecessary grid rebuild. Freed by the
+         * caller. */
+        return calloc(1, sizeof(lv_gridview_data_change_t));
     } else if ((old_list != NULL) != (new_list != NULL)) {
         *num_changes = -1;
         return NULL;
@@ -861,7 +877,12 @@ static lv_gridview_data_change_t *apps_list_detect_change(const apploader_list_t
         }
     }
     *num_changes = 0;
-    return NULL;
+    /* Non-NULL sentinel -- see comment above. num_changes=0 means the widget
+     * never iterates this array, but it must not be NULL or the widget will
+     * still fully recycle and rebuild every visible tile on every poll (the
+     * cause of the cover art flickering on every ~10s refresh), even when
+     * nothing actually changed. */
+    return calloc(1, sizeof(lv_gridview_data_change_t));
 }
 
 static int apps_raw_visible_count(apps_fragment_t *controller, apploader_list_t *list) {


### PR DESCRIPTION
**In short, the app selection flickered every 10 seconds, this fixes it.**

apps_list_detect_change() always returned a NULL changes pointer, even when it determined the list was identical (num_changes=0). lv_gridview_set_data_advanced() treats changes==NULL as 'invalidate everything' regardless of num_changes, so every single poll -- even ones where nothing changed -- fully recycled and rebuilt every visible tile. Compounding this, appitem_bind() unconditionally called coverloader_display() on every rebind, restarting the cover art load even when the tile was already showing the correct app. Together these caused a visible flicker on every ~10s poll.

Fixed by having apps_list_detect_change() return a non-NULL (if empty) sentinel whenever num_changes=0, so the widget skips the unnecessary full rebuild, and by skipping coverloader_display() in appitem_bind() when the view is already displaying the right app's cover.

Confirmed via git history and a live fetch of mariotaku/moonlight-tv's current source that both of these are latent bugs shared with upstream, not something introduced by this fork.

Touches apps.controller.c, same file as the focus-preservation PR (not git-stacked, but overlapping) -- recommend merging one before the other to avoid a conflict.