### PR TITLE
fix: stop settings checkboxes double-toggling on remote OK press

### DIFF
--- a/src/app/ui/settings/panes/pref_obj.c
+++ b/src/app/ui/settings/panes/pref_obj.c
@@ -79,8 +79,12 @@ lv_obj_t *pref_checkbox(lv_obj_t *parent, const char *title, bool *value, bool r
     attrs->checkbox.ref = value;
     attrs->checkbox.reverse = reverse;
     lv_obj_clear_flag(checkbox, LV_OBJ_FLAG_CHECKABLE);
+    /* LVGL's keypad/encoder input handling already synthesizes a CLICKED event
+     * when a focused object receives an ENTER key release (see indev_keypad_proc
+     * in lv_indev.c), so listening on LV_EVENT_KEY here as well double-fires
+     * the toggle for a single remote OK press. CLICKED alone covers both touch
+     * and remote/keypad activation. */
     lv_obj_add_event_cb(checkbox, pref_checkable_activate, LV_EVENT_CLICKED, attrs);
-    lv_obj_add_event_cb(checkbox, pref_checkable_activate, LV_EVENT_KEY, attrs);
     lv_obj_add_event_cb(checkbox, pref_attrs_free, LV_EVENT_DELETE, attrs);
     if (*value ^ reverse) {
         lv_obj_add_state(checkbox, LV_STATE_CHECKED);
@@ -260,11 +264,7 @@ static void pref_checkable_value_write_back(lv_event_t *event) {
 }
 
 static bool pref_checkable_is_activate_event(lv_event_t *event) {
-    lv_event_code_t code = lv_event_get_code(event);
-    if (code == LV_EVENT_CLICKED) {
-        return true;
-    }
-    return code == LV_EVENT_KEY && lv_event_get_key(event) == LV_KEY_ENTER;
+    return lv_event_get_code(event) == LV_EVENT_CLICKED;
 }
 
 static void pref_checkable_activate(lv_event_t *event) {

--- a/src/app/ui/settings/panes/video.pane.c
+++ b/src/app/ui/settings/panes/video.pane.c
@@ -153,8 +153,10 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
                "Off by default; use 10–30 s if you see blockiness or color smearing. Minimum 0.5 s."),
         false);
     controller->idr_refresh_hint = idr_hint;
+    /* LVGL already synthesizes a CLICKED event for a focused object on ENTER
+     * key release (see indev_keypad_proc in lv_indev.c), so also listening on
+     * LV_EVENT_KEY here double-fires the toggle for one remote OK press. */
     lv_obj_add_event_cb(idr_checkbox, idr_checkbox_activate, LV_EVENT_CLICKED, controller);
-    lv_obj_add_event_cb(idr_checkbox, idr_checkbox_activate, LV_EVENT_KEY, controller);
     lv_obj_add_event_cb(idr_slider, idr_refresh_slider_cb, LV_EVENT_VALUE_CHANGED, controller);
     lv_obj_add_event_cb(hevc_checkbox, idr_refresh_hevc_cb, LV_EVENT_VALUE_CHANGED, controller);
     idr_refresh_state_update(controller);
@@ -253,11 +255,7 @@ static void idr_refresh_state_update(video_pane_t *controller) {
 }
 
 static void idr_checkbox_activate(lv_event_t *e) {
-    lv_event_code_t code = lv_event_get_code(e);
-    if (code == LV_EVENT_KEY && lv_event_get_key(e) != LV_KEY_ENTER) {
-        return;
-    }
-    if (code != LV_EVENT_CLICKED && code != LV_EVENT_KEY) {
+    if (lv_event_get_code(e) != LV_EVENT_CLICKED) {
         return;
     }
     lv_obj_t *cb = lv_event_get_current_target(e);


### PR DESCRIPTION
**In short, pressing "enter" on checkboxes works properly now instead of "double clicking".**

LVGL's keypad handling already synthesizes a CLICKED event after an ENTER key release for the focused object (indev_keypad_proc in lv_indev.c). pref_checkable_activate() and idr_checkbox_activate() were also listening on LV_EVENT_KEY for ENTER, so a single remote OK press fired the toggle twice, visually canceling out. Drops the redundant LV_EVENT_KEY registration/handling; CLICKED alone covers touch and remote/keypad activation. Standalone, based on upstream/main.