### PR TITLE
Support punktfunk as a GameStream host

### DIFF
--- a/core/libgamestream/src/mkcert.c
+++ b/core/libgamestream/src/mkcert.c
@@ -64,8 +64,20 @@ static int mkcert_generate_impl(mbedtls_pk_context *key, mbedtls_x509write_cert 
     mbedtls_mpi_read_string(&serial, 10, "1");
     mbedtls_x509write_crt_set_serial(crt, &serial);
 
-    mbedtls_x509write_crt_set_version(crt, MBEDTLS_X509_CRT_VERSION_2);
+    // Use X.509 v3 so that extensions (keyUsage) are supported.
+    // Modern NVIDIA host apps require a v3 client cert during mTLS pairing;
+    // a v2 cert causes a cURL SSL connection error.
+    mbedtls_x509write_crt_set_version(crt, MBEDTLS_X509_CRT_VERSION_3);
     mbedtls_x509write_crt_set_md_alg(crt, MBEDTLS_MD_SHA256);
+
+    // Declare the cert's intended use explicitly, required by strict TLS stacks.
+    if ((ret = mbedtls_x509write_crt_set_key_usage(crt,
+            MBEDTLS_X509_KU_DIGITAL_SIGNATURE | MBEDTLS_X509_KU_KEY_ENCIPHERMENT)) != 0) {
+        mbedtls_strerror(ret, buf, 512);
+        ret = gs_set_error(GS_FAILED, "mbedtls_x509write_crt_set_key_usage returned -0x%04x - %s",
+                           (unsigned int) -ret, buf);
+        goto finally;
+    }
 
     time_t now;
     time(&now);

--- a/src/app/stream/video/session_video.c
+++ b/src/app/stream/video/session_video.c
@@ -64,6 +64,9 @@ static bool need_idr_on_resume = false;
 static struct VIDEO_STATS vdec_temp_stats;
 static int vdec_stream_format = 0;
 static bool vdec_warned_near_buffer_limit;
+/* Set once per stream after the first successful feed, so SS4S_PlayerVideoSetHDRInfo is only
+ * called once the video sink actually exists (a no-op on webOS before then). */
+static bool vdec_hdr_notified;
 VIDEO_STATS vdec_summary_stats;
 /* Seqlock for vdec_summary_stats: odd while vdec_stat_submit is mid-write. */
 static unsigned vdec_stats_seq;
@@ -225,6 +228,7 @@ int vdec_delegate_setup(int videoFormat, int width, int height, int redrawRate, 
     memset(&vdec_stream_info, 0, sizeof(vdec_stream_info));
     vdec_stream_format = videoFormat;
     vdec_stream_info.format = video_format_name(videoFormat);
+    vdec_hdr_notified = false;
     lastFrameNumber = 0;
     need_idr_on_resume = false;
     frames_since_idr = 0;
@@ -308,6 +312,13 @@ void vdec_delegate_cleanup(void) {
 
 static int vdec_finish_feed(SS4S_VideoFeedResult result, PDECODE_UNIT decodeUnit) {
     if (result == SS4S_VIDEO_FEED_OK) {
+        /* Some GameStream-compatible hosts (e.g. punktfunk) never send the async HDR_INFO
+         * control message Sunshine uses to confirm HDR; the negotiated format already tells
+         * us HDR was agreed on, so apply it here once the video sink is confirmed alive. */
+        if (!vdec_hdr_notified && (vdec_stream_format & VIDEO_FORMAT_MASK_10BIT)) {
+            vdec_hdr_notified = true;
+            streaming_set_hdr(session, true);
+        }
         if (decodeUnit->frameType == FRAME_TYPE_IDR) {
             frames_since_idr = 0;
         } else {


### PR DESCRIPTION
**Punktfunk** is a self-hosted game/desktop streaming server, a drop-in alternative to Sunshine that supports the GameStream protocol Moonlight clients use, so this app already mostly worked with it out of the box. Docs: https://docs.punktfunk.unom.io

Two things didn't work, both fixed here:

- Pairing failed with an SSL error. punktfunk's mTLS handshake requires a v3 client certificate; we were generating v2. Added the missing keyUsage extension. Works fine with sunshine hosts.
- HDR streams stayed in SDR picture mode on the TV. Sunshine tells the client "HDR is on" with an async message after the stream starts. punktfunk negotiates HDR correctly but never sends that message, so the TV was never told to switch modes. We now infer HDR from the already-negotiated stream format instead of waiting on that message. 