### PR TITLE
fix: skip audio feed when Opus decode fails

### DIFF
--- a/src/app/stream/audio/session_audio.c
+++ b/src/app/stream/audio/session_audio.c
@@ -142,7 +142,11 @@ static void aud_feed(char *sampleData, int sampleLength) {
     if (decoder != NULL) {
         int decode_len = opus_multistream_decode(decoder, (unsigned char *) sampleData, sampleLength,
                                                  (opus_int16 *) buffer, frame_size, 0);
-        SS4S_PlayerAudioFeed(player, buffer, unit_size * decode_len);
+        // Negative return = decode error (e.g. corrupt packet); feeding
+        // unit_size * decode_len would pass a huge wrapped size downstream.
+        if (decode_len > 0) {
+            SS4S_PlayerAudioFeed(player, buffer, unit_size * decode_len);
+        }
     } else {
         SS4S_PlayerAudioFeed(player, (unsigned char *) sampleData, sampleLength);
     }


### PR DESCRIPTION
On my QNED86T6A I'd sometimes lose audio completely mid-session. Video kept
going, but sound never came back until I quit and opened a new session. I'm
fairly sure this is the cause.

`opus_multistream_decode` returns a negative error code on a corrupt or
truncated packet. We pass that straight through as a size:

    int decode_len = opus_multistream_decode(...);
    SS4S_PlayerAudioFeed(player, buffer, unit_size * decode_len);

`SS4S_PlayerAudioFeed` takes the size as `size_t` (`ss4s/audio.h:60`), so
`unit_size * decode_len` — 4 * -4 for stereo and `OPUS_INVALID_PACKET` — wraps
to about 4.29 billion.

Where that number ends up is what makes it nasty. On webOS the Starfish backend
marshals the buffer address and size as JSON to the media pipeline, which runs
in a separate process (`smp_player.c:140`):

    snprintf(payload, sizeof(payload),
             "{\"bufferAddr\":\"%p\",\"bufferSize\":%u,\"pts\":%llu,\"esData\":%d}",
             data, size, diff, esData);
    StarfishMediaAPIs_feed(ctx->api, payload, result, 256);

So the pipeline is told to read ~4 GB out of our small PCM buffer. Once it's
wedged our side never finds out, because `aud_feed` ignores the feed result
entirely, and audio stays dead until the session is torn down and a new
`AudioOpen` sets up a fresh pipeline. That lines up with what I was seeing.

This isn't an obscure path on webOS either: the Starfish module's
`GetPreferredCodecs` always returns `PCM_S16LE`, and NDL webOS5 only prefers
Opus for 5.1, so in stereo we always decode Opus ourselves and feed PCM.

Fix is to only feed when the decoder actually produced samples — a failed packet
has nothing to play, so dropping it is the right thing to do regardless.

The same unguarded code is in mariotaku/moonlight-tv, so this probably belongs
upstream as well.

**Testing:** built on Linux and running on my QNED86T6A. I haven't lost audio
since. It's an intermittent fault so I can't call that conclusive, but it was
happening regularly enough before that I'd have expected to hit it by now.
