### PR TITLE
Changed 5.1 audio channel mapping sent to host.

### DIFF
--- a/src/app/stream/audio/session_audio.c
+++ b/src/app/stream/audio/session_audio.c
@@ -1,5 +1,4 @@
 #include <stdlib.h>
-#include <string.h>
 #include <assert.h>
 
 #include <opus_multistream.h>
@@ -21,37 +20,6 @@ AUDIO_INFO audio_stream_info;
 
 static size_t opus_head_serialize(const OPUS_MULTISTREAM_CONFIGURATION *config, unsigned char *data);
 
-#if TARGET_WEBOS
-/* NDL/webOS Opus 5.1 layout (FL FR RL RR C LFE). Same as surround_params "642014523". */
-static const unsigned char WEBOS_OPUS_51_MAPPING[6] = {0, 1, 4, 5, 2, 3};
-
-static void maybe_remap_webos_51(OPUS_MULTISTREAM_CONFIGURATION *config) {
-    if (config->channelCount != 6) {
-        return;
-    }
-    /* Hosts that honor surround_params already send webOS order — remapping again
-     * swaps channels (regression for Apollo on some sets after #50). Only remap when
-     * the stream is still in Moonlight/SDL order (FL FR C LFE RL RR). */
-    if (memcmp(config->mapping, WEBOS_OPUS_51_MAPPING, sizeof(WEBOS_OPUS_51_MAPPING)) == 0) {
-        commons_log_info("Session", "5.1 Opus mapping already webOS order; skip remap");
-        return;
-    }
-
-    unsigned char tmp;
-    /* Center (2) <-> Surround Left (4); LFE (3) <-> Surround Right (5) */
-    tmp = config->mapping[2];
-    config->mapping[2] = config->mapping[4];
-    config->mapping[4] = tmp;
-    tmp = config->mapping[3];
-    config->mapping[3] = config->mapping[5];
-    config->mapping[5] = tmp;
-    commons_log_info("Session",
-                     "5.1 Opus mapping remapped to webOS order [%u,%u,%u,%u,%u,%u]",
-                     config->mapping[0], config->mapping[1], config->mapping[2],
-                     config->mapping[3], config->mapping[4], config->mapping[5]);
-}
-#endif
-
 static int aud_init(int audioConfiguration, const POPUS_MULTISTREAM_CONFIGURATION opusConfig, void *context,
                     int arFlags) {
     (void) audioConfiguration;
@@ -61,18 +29,11 @@ static int aud_init(int audioConfiguration, const POPUS_MULTISTREAM_CONFIGURATIO
     player = session->player;
     SS4S_AudioCodec codec = SS4S_AUDIO_PCM_S16LE;
     size_t codecDataLen = 0;
-
-    OPUS_MULTISTREAM_CONFIGURATION config_copy = *opusConfig;
-
-#if TARGET_WEBOS
-    maybe_remap_webos_51(&config_copy);
-#endif
-
     SS4S_AudioInfo info = {
-            .numOfChannels = config_copy.channelCount,
+            .numOfChannels = opusConfig->channelCount,
             .appName = "Aurora",
             .streamName = "Streaming",
-            .sampleRate = config_copy.sampleRate,
+            .sampleRate = opusConfig->sampleRate,
             .samplesPerFrame = SAMPLES_PER_FRAME,
     };
     if (session->audio_cap.codecs & SS4S_AUDIO_OPUS && SS4S_GetAudioPreferredCodecs(&info) & SS4S_AUDIO_OPUS) {
@@ -83,16 +44,16 @@ static int aud_init(int audioConfiguration, const POPUS_MULTISTREAM_CONFIGURATIO
             commons_log_error("Session", "Audio init: failed to allocate codec data buffer");
             return -1;
         }
-        codecDataLen = opus_head_serialize(&config_copy, buffer);
+        codecDataLen = opus_head_serialize(opusConfig, buffer);
     } else {
         int rc;
-        decoder = opus_multistream_decoder_create(config_copy.sampleRate, config_copy.channelCount, config_copy.streams,
-                                                  config_copy.coupledStreams, config_copy.mapping, &rc);
+        decoder = opus_multistream_decoder_create(opusConfig->sampleRate, opusConfig->channelCount, opusConfig->streams,
+                                                  opusConfig->coupledStreams, opusConfig->mapping, &rc);
         if (rc != 0) {
             return rc;
         }
-        frame_size = config_copy.samplesPerFrame;
-        unit_size = (int) (config_copy.channelCount * sizeof(int16_t));
+        frame_size = opusConfig->samplesPerFrame;
+        unit_size = (int) (opusConfig->channelCount * sizeof(int16_t));
         buffer = calloc(unit_size, frame_size);
         if (buffer == NULL) {
             commons_log_error("Session", "Audio init: failed to allocate decode buffer");

--- a/src/app/stream/session_worker.c
+++ b/src/app/stream/session_worker.c
@@ -107,8 +107,9 @@ int session_worker(session_t *session) {
     const char *surround_params = NULL;
 #if TARGET_WEBOS
     if (session->config.stream.audioConfiguration == AUDIO_CONFIGURATION_51_SURROUND) {
-        // 6 channels, 4 streams, 2 coupled streams, FL, FR, SL, SR, FC, LFE
-        surround_params = "642014523";
+        // Send standard channel order so all hosts use the same layout.
+        // This is then remapped to the WebOS order in opus_fix.c from SS4S.
+        surround_params = "642012345";
     }
 #endif
     short gamepad_mask = app_input_gamepads_mask(&app->input);


### PR DESCRIPTION
This is a follow-up to #50 and the change after which made it conditional. After investigating more extensively, I found that the channel order mismatch between Opus and WebOS is already addressed twice in the code, which was the actual cause of this issue. The SS4S module remaps the channels from the Opus ordering to the WebOS ordering in webos5/opus_fix.c, but here we also request that the host use the WebOS ordering through surround_params. On Apollo hosts, the surround_params is not used, so only one order swap actually occurs, meaning that setup worked correctly before #50. However I was using a Linux host which does reorder channels based on surround_params, but it was then being swapped back by opus_fix.c. Therefore adding a third swap in #50 fixed it for me but regressed Apollo users. Instead we can fix for all hosts by simply providing the normal channel order in surround_params, so both hosts send the same channel order and leave opus_fix.c to handle the WebOS remapping. I've also reverted the changes to session_audio.c since the conditional change did not work for me and is no longer necessary. I've tested with both Apollo on Windows and Sunshine on Linux and confirmed this allows 5.1 surround to work for both!